### PR TITLE
chore: Use the latest mysql:11 docker image for tests.

### DIFF
--- a/.github/tests/docker-compose.yml
+++ b/.github/tests/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - default
 
   mysql:
-    image: public.ecr.aws/unocha/mysql:11.4
+    image: public.ecr.aws/unocha/mysql:11
     hostname: ghi-test-mysql
     container_name: ghi-test-mysql
     environment:
@@ -51,6 +51,8 @@ services:
       # Mount local custom code.
       #- "../html/modules/custom:/srv/www/html/modules/custom:ro"
       #- "../html/themes/custom:/srv/www/html/themes/custom:ro"
+      # Build logs.
+      - "../../logs:/srv/www/html/build/logs:rw"
     environment:
       - TERM=xterm
       - ENVIRONMENT=dev


### PR DESCRIPTION
This is now MariaDB 11.8.6, which matches RDS dev.

Refs: OPS-12081