### PR TITLE
release versions/v1.18.1

### DIFF
--- a/.docksal/commands/deploy
+++ b/.docksal/commands/deploy
@@ -60,7 +60,7 @@ if $IMPORT_BACKUP; then
     drush sql:drop -y >/dev/null
 
     echo "Importing ${FILENAME}"
-    drush sql:query -y --file=${FILEPATH} --extra=-f >/dev/null
+    drush sql:query -y --file=${FILEPATH} --extra="--ssl=0 -f" >/dev/null
     echo "Import finished"
   else
     echo "No backup found in ${BACKUP_DIRECTORY}"

--- a/.docksal/default.docksal-local.env
+++ b/.docksal/default.docksal-local.env
@@ -5,6 +5,7 @@ HPC_API_KEY=''
 
 # Credentials for Content Module.
 CM_KEY=''
+CM_WEBHOOK_SECRET=''
 
 # Mapbox token.
 MAPBOX_TOKEN=''

--- a/.docksal/docksal.yml
+++ b/.docksal/docksal.yml
@@ -7,6 +7,7 @@ services:
       - HPC_API_PASS
       - HPC_API_KEY
       - CM_KEY
+      - CM_WEBHOOK_SECRET
       - MAPBOX_TOKEN
       - COMPOSER_MEMORY_LIMIT=-1
       - SOLR_CORE
@@ -18,6 +19,7 @@ services:
 
   web:
     environment:
+      - CM_WEBHOOK_SECRET
       - MAPBOX_TOKEN
 
   browser:

--- a/html/modules/custom/ghi_content/config/schema/remote_sources.schema.yml
+++ b/html/modules/custom/ghi_content/config/schema/remote_sources.schema.yml
@@ -2,11 +2,15 @@ ghi_content.remote_sources:
   type: sequence
   label: 'Remote sources'
   sequence:
-    type: ghi_content.remote_sources.*
+    type: ghi_content.remote_sources.[%key]
     constraints:
       ValidKeys: '<infer>'
 
 ghi_content.remote_sources.*:
+  type: ghi_content.remote_source
+  label: 'Remote source'
+
+ghi_content.remote_source:
   type: mapping
   label: 'Remote source'
   mapping:
@@ -40,3 +44,22 @@ ghi_content.remote_sources.*:
           label: 'Password'
           constraints:
             PrimitiveType: []
+
+# Plugin-specific schema for \Drupal\ghi_content\Plugin\RemoteSource\HpcContentModule.
+ghi_content.remote_sources.hpc_content_module:
+  type: ghi_content.remote_source
+  label: 'HPC Content Module remote source'
+  mapping:
+    remote_refresh:
+      type: mapping
+      label: 'Remote refresh'
+      mapping:
+        webhook_secret:
+          type: string
+          label: 'Webhook secret'
+        signature_ttl:
+          type: integer
+          label: 'Signature TTL'
+        max_body_size:
+          type: integer
+          label: 'Maximum body size'

--- a/html/modules/custom/ghi_content/ghi_content.routing.yml
+++ b/html/modules/custom/ghi_content/ghi_content.routing.yml
@@ -42,6 +42,16 @@ ghi_content.remote.settings:
       remote_source:
         type: 'remote_source'
 
+ghi_content.remote_refresh.webhook:
+  path: '/webhooks/content/remote-refresh'
+  defaults:
+    _controller: '\Drupal\ghi_content\Controller\RemoteRefreshController::receive'
+    _title: 'Remote content refresh webhook'
+  requirements:
+    # Access is enforced by an HMAC signature in the controller.
+    _access: 'TRUE'
+  methods: [POST]
+
 ghi_content.node.articles:
   path: '/node/{node}/articles'
   defaults:

--- a/html/modules/custom/ghi_content/ghi_content.services.yml
+++ b/html/modules/custom/ghi_content/ghi_content.services.yml
@@ -14,6 +14,9 @@ services:
   ghi_content.import:
     class: Drupal\ghi_content\Import\ImportManager
     arguments: ['@config.factory', '@entity_type.manager', '@plugin.manager.block', '@current_user', '@uuid', '@layout_builder.tempstore_repository', '@plugin.manager.entity_reference_selection', '@file.repository', '@event_dispatcher']
+  ghi_content.targeted_migration_importer:
+    class: Drupal\ghi_content\Import\TargetedMigrationImporter
+    arguments: ['@keyvalue', '@datetime.time', '@string_translation']
   ghi_content.subarticle_renderer:
     class: Drupal\ghi_content\SubArticleRenderer
     arguments: ['@context.repository']

--- a/html/modules/custom/ghi_content/ghi_content.services.yml
+++ b/html/modules/custom/ghi_content/ghi_content.services.yml
@@ -1,4 +1,7 @@
 services:
+  logger.channel.ghi_content:
+    parent: logger.channel_base
+    arguments: ['ghi_content']
   plugin.manager.remote_source:
     class: Drupal\ghi_content\RemoteSource\RemoteSourceManager
     parent: default_plugin_manager

--- a/html/modules/custom/ghi_content/src/ContentManager/ArticleManager.php
+++ b/html/modules/custom/ghi_content/src/ContentManager/ArticleManager.php
@@ -186,10 +186,10 @@ class ArticleManager extends BaseContentManager {
   /**
    * {@inheritdoc}
    */
-  public function updateNodeFromRemote(ContentBase $node, $dry_run = FALSE, $reset = FALSE) {
+  public function updateNodeFromRemote(ContentBase $node, $dry_run = FALSE, $reset = FALSE): bool {
     $article = $this->loadRemoteContentForNode($node, TRUE, FALSE);
     if (!$article) {
-      return;
+      return FALSE;
     }
 
     // See if the article needs a cleanup.
@@ -231,6 +231,7 @@ class ArticleManager extends BaseContentManager {
       $this->importManager->layoutManagerDiscardChanges($node, NULL);
       $node->setSyncing(TRUE);
     }
+    return TRUE;
   }
 
   /**

--- a/html/modules/custom/ghi_content/src/ContentManager/BaseContentManager.php
+++ b/html/modules/custom/ghi_content/src/ContentManager/BaseContentManager.php
@@ -187,11 +187,13 @@ abstract class BaseContentManager implements ContainerInjectionInterface {
    *   The remote source as a string.
    * @param int[] $ids
    *   An array of ids to load from the source.
+   * @param bool $reload
+   *   Whether to bypass any cached lookup result for the given ids.
    *
    * @return \Drupal\ghi_content\Entity\ContentBase[]
    *   An array of node objects.
    */
-  public function loadNodesForRemoteIds(string $source, array $ids) {
+  public function loadNodesForRemoteIds(string $source, array $ids, bool $reload = FALSE) {
     if (empty($ids)) {
       return [];
     }
@@ -202,6 +204,14 @@ abstract class BaseContentManager implements ContainerInjectionInterface {
     ]);
     $cache = &drupal_static(__METHOD__, []);
     $cache[$cache_key] ??= [];
+    if ($reload) {
+      // A caller may have just imported content that was cached as missing
+      // earlier in the same request. Drop only the requested ids so unrelated
+      // lookups keep benefiting from the request-static cache.
+      foreach ($ids as $id) {
+        unset($cache[$cache_key][$id]);
+      }
+    }
 
     // Cache each remote id individually so overlapping chapter/article lists
     // only query the ids that have not already been resolved in this request.
@@ -653,9 +663,12 @@ abstract class BaseContentManager implements ContainerInjectionInterface {
    *   Whether node should be reset to it's original state (as if it would be
    *   created right now based on the configuration on the remote).
    *
+   * @return bool
+   *   TRUE if remote data was applied to the node, FALSE otherwise.
+   *
    * @see ghi_content_node_presave()
    */
-  abstract public function updateNodeFromRemote(ContentBase $node, $dry_run = FALSE, $reset = FALSE);
+  abstract public function updateNodeFromRemote(ContentBase $node, $dry_run = FALSE, $reset = FALSE): bool;
 
   /**
    * Check if the given node is in-sync with its remote source.

--- a/html/modules/custom/ghi_content/src/ContentManager/DocumentManager.php
+++ b/html/modules/custom/ghi_content/src/ContentManager/DocumentManager.php
@@ -162,10 +162,10 @@ class DocumentManager extends BaseContentManager {
   /**
    * {@inheritdoc}
    */
-  public function updateNodeFromRemote(ContentBase $node, $dry_run = FALSE, $reset = FALSE) {
+  public function updateNodeFromRemote(ContentBase $node, $dry_run = FALSE, $reset = FALSE): bool {
     $document = $this->loadRemoteContentForNode($node, TRUE);
     if (!$document) {
-      return;
+      return FALSE;
     }
 
     // See if the document needs a cleanup.
@@ -202,6 +202,7 @@ class DocumentManager extends BaseContentManager {
     if (!$dry_run) {
       $this->importManager->layoutManagerDiscardChanges($node, NULL);
     }
+    return TRUE;
   }
 
   /**

--- a/html/modules/custom/ghi_content/src/ContentManager/ManagerFactory.php
+++ b/html/modules/custom/ghi_content/src/ContentManager/ManagerFactory.php
@@ -51,4 +51,21 @@ class ManagerFactory {
     return NULL;
   }
 
+  /**
+   * Get the content manager for an incoming remote content type.
+   *
+   * @param string $type
+   *   The remote content type.
+   *
+   * @return \Drupal\ghi_content\ContentManager\BaseContentManager|null
+   *   The content manager.
+   */
+  public function getContentManagerForRemoteType(string $type): ?BaseContentManager {
+    return match ($type) {
+      'article' => $this->articleManager,
+      'document' => $this->documentManager,
+      default => NULL,
+    };
+  }
+
 }

--- a/html/modules/custom/ghi_content/src/Controller/RemoteRefreshController.php
+++ b/html/modules/custom/ghi_content/src/Controller/RemoteRefreshController.php
@@ -130,6 +130,14 @@ class RemoteRefreshController extends ControllerBase {
       return new JsonResponse(['queued' => FALSE], Response::HTTP_ACCEPTED);
     }
 
+    if (($payload['event'] ?? NULL) === 'ping') {
+      $this->logger->info('Validated @event event from @source.', [
+        '@event' => $payload['event'],
+        '@source' => $payload['source'],
+      ]);
+      return new JsonResponse(['checked' => TRUE], Response::HTTP_ACCEPTED);
+    }
+
     $item = (object) [
       'source' => $payload['source'],
       'type' => $payload['type'],
@@ -278,7 +286,7 @@ class RemoteRefreshController extends ControllerBase {
     if (empty($payload['id']) || !is_numeric($payload['id'])) {
       $errors[] = 'Missing content id.';
     }
-    if (isset($payload['event']) && !in_array($payload['event'], ['saved', 'trashed', 'deleted'], TRUE)) {
+    if (isset($payload['event']) && !in_array($payload['event'], ['saved', 'trashed', 'deleted', 'ping'], TRUE)) {
       $errors[] = 'Unsupported event.';
     }
     if (empty($payload['deliveryId']) || !is_string($payload['deliveryId']) || !Uuid::isValid($payload['deliveryId'])) {

--- a/html/modules/custom/ghi_content/src/Controller/RemoteRefreshController.php
+++ b/html/modules/custom/ghi_content/src/Controller/RemoteRefreshController.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Drupal\ghi_content\Controller;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\ghi_content\RemoteSource\RemoteRefreshSourceInterface;
+use Drupal\ghi_content\RemoteSource\RemoteSourceManager;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Receives signed remote content refresh notifications.
+ *
+ * The contrib Webhooks module is a possible generic alternative:
+ * https://www.drupal.org/project/webhooks. This receiver stays custom while
+ * that module is alpha and does not provide the replay protection, secret
+ * handling, and narrow CM-to-HA contract we need here.
+ */
+class RemoteRefreshController extends ControllerBase {
+
+  /**
+   * Queue id for remote content refresh jobs.
+   */
+  const QUEUE_ID = 'ghi_content_remote_refresh';
+
+  /**
+   * The queue factory.
+   *
+   * @var \Drupal\Core\Queue\QueueFactory
+   */
+  protected $queueFactory;
+
+  /**
+   * The remote source plugin manager.
+   *
+   * @var \Drupal\ghi_content\RemoteSource\RemoteSourceManager
+   */
+  protected $remoteSourceManager;
+
+  /**
+   * Remote refresh source instances keyed by source id.
+   *
+   * @var \Drupal\ghi_content\RemoteSource\RemoteRefreshSourceInterface[]
+   */
+  protected $remoteSources = [];
+
+  /**
+   * Logger channel.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a remote refresh controller.
+   */
+  public function __construct(QueueFactory $queue_factory, RemoteSourceManager $remote_source_manager, LoggerInterface $logger) {
+    $this->queueFactory = $queue_factory;
+    $this->remoteSourceManager = $remote_source_manager;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('queue'),
+      $container->get('plugin.manager.remote_source'),
+      $container->get('logger.channel.ghi_content')
+    );
+  }
+
+  /**
+   * Receive a refresh notification.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request object.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The response.
+   */
+  public function receive(Request $request) {
+    $body = $request->getContent();
+    if (strlen($body) > $this->getConfiguredMaxBodySize()) {
+      return new JsonResponse(['message' => 'Payload too large.'], Response::HTTP_REQUEST_ENTITY_TOO_LARGE);
+    }
+
+    try {
+      $payload = Json::decode($body);
+    }
+    catch (\Exception $e) {
+      return new JsonResponse(['message' => 'Invalid JSON.'], Response::HTTP_BAD_REQUEST);
+    }
+
+    $errors = $this->validatePayload($payload);
+    if (!empty($errors)) {
+      return new JsonResponse(['message' => implode(' ', $errors)], Response::HTTP_BAD_REQUEST);
+    }
+
+    if (strlen($body) > $this->getMaxBodySize($payload['source'])) {
+      return new JsonResponse(['message' => 'Payload too large.'], Response::HTTP_REQUEST_ENTITY_TOO_LARGE);
+    }
+
+    if (!$this->validateSignature($request, $body, $payload['source'])) {
+      return new JsonResponse(['message' => 'Invalid signature.'], Response::HTTP_FORBIDDEN);
+    }
+
+    $item = (object) [
+      'source' => $payload['source'],
+      'type' => $payload['type'],
+      'id' => (int) $payload['id'],
+      'status' => isset($payload['status']) ? (int) $payload['status'] : NULL,
+      'changed' => isset($payload['changed']) ? (int) $payload['changed'] : NULL,
+      'force_update' => isset($payload['forceUpdate']) ? (int) $payload['forceUpdate'] : NULL,
+      'event' => $payload['event'] ?? NULL,
+      'received' => time(),
+    ];
+    $this->queueFactory->get(self::QUEUE_ID)->createItem($item);
+
+    $this->logger->info('Queued remote refresh for @type @id from @source.', [
+      '@type' => $item->type,
+      '@id' => $item->id,
+      '@source' => $item->source,
+    ]);
+
+    return new JsonResponse(['queued' => TRUE], Response::HTTP_ACCEPTED);
+  }
+
+  /**
+   * Validate the request signature.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request object.
+   * @param string $body
+   *   The raw request body.
+   * @param string $source
+   *   The remote source id.
+   *
+   * @return bool
+   *   TRUE if the signature is valid, FALSE otherwise.
+   */
+  private function validateSignature(Request $request, string $body, string $source): bool {
+    $remote_source = $this->getRemoteSource($source);
+    $secret = $remote_source?->getRemoteRefreshWebhookSecret();
+    if (empty($secret)) {
+      $this->logger->warning('Remote refresh webhook called for @source before a secret was configured.', [
+        '@source' => $source,
+      ]);
+      return FALSE;
+    }
+
+    $timestamp = $request->headers->get('X-NCMS-Timestamp');
+    $signature = $request->headers->get('X-NCMS-Signature');
+    if (!$timestamp || !$signature || !ctype_digit((string) $timestamp)) {
+      return FALSE;
+    }
+
+    $ttl = $remote_source->getRemoteRefreshSignatureTtl();
+    if (abs(time() - (int) $timestamp) > $ttl) {
+      return FALSE;
+    }
+
+    $expected = 'sha256=' . hash_hmac('sha256', $timestamp . '.' . $body, $secret);
+    return hash_equals($expected, $signature);
+  }
+
+  /**
+   * Get the maximum allowed webhook request body size.
+   *
+   * @return int
+   *   The maximum body size in bytes.
+   */
+  private function getMaxBodySize(string $source): int {
+    return $this->getRemoteSource($source)?->getRemoteRefreshMaxBodySize() ?? 4096;
+  }
+
+  /**
+   * Get the largest configured webhook request body size.
+   *
+   * @return int
+   *   The maximum configured body size in bytes.
+   */
+  private function getConfiguredMaxBodySize(): int {
+    $max_body_size = 4096;
+    foreach (array_keys($this->remoteSourceManager->getDefinitions()) as $source) {
+      $max_body_size = max($max_body_size, $this->getMaxBodySize($source));
+    }
+    return $max_body_size;
+  }
+
+  /**
+   * Get a remote refresh source plugin instance.
+   *
+   * @param string $source
+   *   The remote source id.
+   *
+   * @return \Drupal\ghi_content\RemoteSource\RemoteRefreshSourceInterface|null
+   *   The remote source if it supports remote refresh notifications.
+   */
+  private function getRemoteSource(string $source): ?RemoteRefreshSourceInterface {
+    if (isset($this->remoteSources[$source])) {
+      return $this->remoteSources[$source];
+    }
+    if (!array_key_exists($source, $this->remoteSourceManager->getDefinitions())) {
+      return NULL;
+    }
+    $remote_source = $this->remoteSourceManager->createInstance($source);
+    if (!$remote_source instanceof RemoteRefreshSourceInterface) {
+      return NULL;
+    }
+    $this->remoteSources[$source] = $remote_source;
+    return $this->remoteSources[$source];
+  }
+
+  /**
+   * Validate the decoded payload.
+   *
+   * @param mixed $payload
+   *   The decoded payload.
+   *
+   * @return string[]
+   *   Validation errors.
+   */
+  private function validatePayload($payload): array {
+    $errors = [];
+    if (!is_array($payload)) {
+      return ['Payload must be an object.'];
+    }
+    if (empty($payload['source']) || !is_string($payload['source']) || !$this->getRemoteSource($payload['source'])) {
+      $errors[] = 'Unsupported source.';
+    }
+    if (!in_array($payload['type'] ?? NULL, ['article', 'document'])) {
+      $errors[] = 'Unsupported content type.';
+    }
+    if (empty($payload['id']) || !is_numeric($payload['id'])) {
+      $errors[] = 'Missing content id.';
+    }
+    return $errors;
+  }
+
+}

--- a/html/modules/custom/ghi_content/src/Controller/RemoteRefreshController.php
+++ b/html/modules/custom/ghi_content/src/Controller/RemoteRefreshController.php
@@ -3,7 +3,9 @@
 namespace Drupal\ghi_content\Controller;
 
 use Drupal\Component\Serialization\Json;
+use Drupal\Component\Uuid\Uuid;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\ghi_content\RemoteSource\RemoteRefreshSourceInterface;
 use Drupal\ghi_content\RemoteSource\RemoteSourceManager;
@@ -43,6 +45,13 @@ class RemoteRefreshController extends ControllerBase {
   protected $remoteSourceManager;
 
   /**
+   * The expirable key/value store factory.
+   *
+   * @var \Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface
+   */
+  protected $keyValueExpirableFactory;
+
+  /**
    * Remote refresh source instances keyed by source id.
    *
    * @var \Drupal\ghi_content\RemoteSource\RemoteRefreshSourceInterface[]
@@ -59,9 +68,10 @@ class RemoteRefreshController extends ControllerBase {
   /**
    * Constructs a remote refresh controller.
    */
-  public function __construct(QueueFactory $queue_factory, RemoteSourceManager $remote_source_manager, LoggerInterface $logger) {
+  public function __construct(QueueFactory $queue_factory, RemoteSourceManager $remote_source_manager, KeyValueExpirableFactoryInterface $key_value_expirable_factory, LoggerInterface $logger) {
     $this->queueFactory = $queue_factory;
     $this->remoteSourceManager = $remote_source_manager;
+    $this->keyValueExpirableFactory = $key_value_expirable_factory;
     $this->logger = $logger;
   }
 
@@ -72,6 +82,7 @@ class RemoteRefreshController extends ControllerBase {
     return new static(
       $container->get('queue'),
       $container->get('plugin.manager.remote_source'),
+      $container->get('keyvalue.expirable'),
       $container->get('logger.channel.ghi_content')
     );
   }
@@ -111,6 +122,14 @@ class RemoteRefreshController extends ControllerBase {
       return new JsonResponse(['message' => 'Invalid signature.'], Response::HTTP_FORBIDDEN);
     }
 
+    if (!$this->claimDeliveryId($payload)) {
+      $this->logger->notice('Rejected duplicate remote refresh delivery @delivery_id from @source.', [
+        '@delivery_id' => $payload['deliveryId'],
+        '@source' => $payload['source'],
+      ]);
+      return new JsonResponse(['queued' => FALSE], Response::HTTP_ACCEPTED);
+    }
+
     $item = (object) [
       'source' => $payload['source'],
       'type' => $payload['type'],
@@ -119,11 +138,13 @@ class RemoteRefreshController extends ControllerBase {
       'changed' => isset($payload['changed']) ? (int) $payload['changed'] : NULL,
       'force_update' => isset($payload['forceUpdate']) ? (int) $payload['forceUpdate'] : NULL,
       'event' => $payload['event'] ?? NULL,
+      'delivery_id' => $payload['deliveryId'],
       'received' => time(),
     ];
     $this->queueFactory->get(self::QUEUE_ID)->createItem($item);
 
-    $this->logger->info('Queued remote refresh for @type @id from @source.', [
+    $this->logger->info('Queued @event event for @type @id from @source.', [
+      '@event' => $item->event ?? 'unknown',
       '@type' => $item->type,
       '@id' => $item->id,
       '@source' => $item->source,
@@ -181,6 +202,22 @@ class RemoteRefreshController extends ControllerBase {
   }
 
   /**
+   * Claim a delivery id so the same signed request cannot be replayed.
+   *
+   * @param array $payload
+   *   The validated payload.
+   *
+   * @return bool
+   *   TRUE if this delivery id has not been seen before, FALSE otherwise.
+   */
+  private function claimDeliveryId(array $payload): bool {
+    $remote_source = $this->getRemoteSource($payload['source']);
+    $ttl = $remote_source?->getRemoteRefreshSignatureTtl() ?? 300;
+    $store = $this->keyValueExpirableFactory->get('ghi_content_remote_refresh_deliveries');
+    return $store->setWithExpireIfNotExists($payload['source'] . ':' . $payload['deliveryId'], TRUE, max(1, $ttl) + 60);
+  }
+
+  /**
    * Get the largest configured webhook request body size.
    *
    * @return int
@@ -235,11 +272,17 @@ class RemoteRefreshController extends ControllerBase {
     if (empty($payload['source']) || !is_string($payload['source']) || !$this->getRemoteSource($payload['source'])) {
       $errors[] = 'Unsupported source.';
     }
-    if (!in_array($payload['type'] ?? NULL, ['article', 'document'])) {
+    if (!in_array($payload['type'] ?? NULL, ['article', 'document'], TRUE)) {
       $errors[] = 'Unsupported content type.';
     }
     if (empty($payload['id']) || !is_numeric($payload['id'])) {
       $errors[] = 'Missing content id.';
+    }
+    if (isset($payload['event']) && !in_array($payload['event'], ['saved', 'trashed', 'deleted'], TRUE)) {
+      $errors[] = 'Unsupported event.';
+    }
+    if (empty($payload['deliveryId']) || !is_string($payload['deliveryId']) || !Uuid::isValid($payload['deliveryId'])) {
+      $errors[] = 'Missing delivery id.';
     }
     return $errors;
   }

--- a/html/modules/custom/ghi_content/src/Controller/RemoteRefreshController.php
+++ b/html/modules/custom/ghi_content/src/Controller/RemoteRefreshController.php
@@ -142,9 +142,7 @@ class RemoteRefreshController extends ControllerBase {
       'source' => $payload['source'],
       'type' => $payload['type'],
       'id' => (int) $payload['id'],
-      'status' => isset($payload['status']) ? (int) $payload['status'] : NULL,
       'changed' => isset($payload['changed']) ? (int) $payload['changed'] : NULL,
-      'force_update' => isset($payload['forceUpdate']) ? (int) $payload['forceUpdate'] : NULL,
       'event' => $payload['event'] ?? NULL,
       'delivery_id' => $payload['deliveryId'],
       'received' => time(),
@@ -286,7 +284,12 @@ class RemoteRefreshController extends ControllerBase {
     if (empty($payload['id']) || !is_numeric($payload['id'])) {
       $errors[] = 'Missing content id.';
     }
-    if (isset($payload['event']) && !in_array($payload['event'], ['saved', 'trashed', 'deleted', 'ping'], TRUE)) {
+    if (empty($payload['event']) || !is_string($payload['event']) || !in_array($payload['event'], [
+      'saved',
+      'trashed',
+      'deleted',
+      'ping',
+    ], TRUE)) {
       $errors[] = 'Unsupported event.';
     }
     if (empty($payload['deliveryId']) || !is_string($payload['deliveryId']) || !Uuid::isValid($payload['deliveryId'])) {

--- a/html/modules/custom/ghi_content/src/Form/RemoteSourceEditForm.php
+++ b/html/modules/custom/ghi_content/src/Form/RemoteSourceEditForm.php
@@ -50,8 +50,9 @@ class RemoteSourceEditForm extends FormBase {
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
     $form_state->cleanValues();
-    $this->remoteSource->setConfiguration($form_state->getValue('settings'));
-    if (!$this->remoteSource->checkConnection()) {
+    $remote_source = clone $this->remoteSource;
+    $remote_source->setConfiguration($form_state->getValue('settings'));
+    if (!$remote_source->checkConnection()) {
       $form_state->setErrorByName('settings', $this->t('The connection to the @remote_label failed with the given settings', [
         '@remote_label' => $this->remoteSource->getPluginLabel(),
       ]));

--- a/html/modules/custom/ghi_content/src/Import/TargetedMigrationImporter.php
+++ b/html/modules/custom/ghi_content/src/Import/TargetedMigrationImporter.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\ghi_content\Import;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\migrate\MigrateMessage;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate_tools\MigrateExecutable;
+
+/**
+ * Runs targeted migration imports for individual remote content items.
+ */
+class TargetedMigrationImporter {
+
+  /**
+   * The key-value store factory.
+   *
+   * @var \Drupal\Core\KeyValueStore\KeyValueFactoryInterface
+   */
+  protected $keyValueFactory;
+
+  /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $time;
+
+  /**
+   * The string translation service.
+   *
+   * @var \Drupal\Core\StringTranslation\TranslationInterface
+   */
+  protected $stringTranslation;
+
+  /**
+   * Constructs a targeted migration importer.
+   *
+   * @param \Drupal\Core\KeyValueStore\KeyValueFactoryInterface $key_value_factory
+   *   The key-value store factory.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   */
+  public function __construct(KeyValueFactoryInterface $key_value_factory, TimeInterface $time, TranslationInterface $string_translation) {
+    $this->keyValueFactory = $key_value_factory;
+    $this->time = $time;
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Run a targeted import for one remote item.
+   *
+   * @param \Drupal\migrate\Plugin\MigrationInterface $migration
+   *   The migration to run.
+   * @param int $remote_id
+   *   The remote content id.
+   *
+   * @return bool
+   *   TRUE if the migration did not fail, FALSE otherwise.
+   */
+  public function import(MigrationInterface $migration, int $remote_id): bool {
+    $options = [
+      'idlist' => (string) $remote_id,
+      'update' => TRUE,
+    ];
+
+    // This mirrors migrate_tools' --update --idlist preparation. Passing an
+    // idlist to the executable only filters the source rows; the corresponding
+    // id map row still needs to be marked as updateable when the item has been
+    // imported before.
+    $source_id_keys = array_keys($migration->getSourcePlugin()->getIds());
+    $migration->getIdMap()->setUpdate(array_combine($source_id_keys, [(string) $remote_id]));
+
+    // Use the existing migration for creation instead of manually creating a
+    // node here. That keeps the source-to-destination id map in sync, so the
+    // next scheduled migration updates this node instead of importing a
+    // duplicate for the same remote item.
+    $executable = new MigrateExecutable($migration, new MigrateMessage(), $this->keyValueFactory, $this->time, $this->stringTranslation, $options);
+    return $executable->import() !== MigrationInterface::RESULT_FAILED;
+  }
+
+}

--- a/html/modules/custom/ghi_content/src/Plugin/QueueWorker/RemoteRefreshQueue.php
+++ b/html/modules/custom/ghi_content/src/Plugin/QueueWorker/RemoteRefreshQueue.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Drupal\ghi_content\Plugin\QueueWorker;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\Attribute\QueueWorker;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ghi_content\ContentManager\ArticleManager;
+use Drupal\ghi_content\ContentManager\DocumentManager;
+use Drupal\ghi_content\Entity\ContentBase;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Refreshes local content after remote content notifications.
+ */
+#[QueueWorker(
+  id: 'ghi_content_remote_refresh',
+  title: new TranslatableMarkup('Remote content refresh'),
+  cron: ['time' => 60]
+)]
+final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The content manager factory.
+   *
+   * @var \Drupal\ghi_content\ContentManager\ManagerFactory
+   */
+  protected $managerFactory;
+
+  /**
+   * The lock backend.
+   *
+   * @var \Drupal\Core\Lock\LockBackendInterface
+   */
+  protected $lock;
+
+  /**
+   * Logger channel.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+    $instance->managerFactory = $container->get('ghi_content.manager.factory');
+    $instance->lock = $container->get('lock');
+    $instance->logger = $container->get('logger.channel.ghi_content');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    $source = $data->source ?? NULL;
+    $type = $data->type ?? NULL;
+    $remote_id = isset($data->id) ? (int) $data->id : NULL;
+    if (!$source || !$type || !$remote_id) {
+      return;
+    }
+
+    $lock_id = implode(':', ['ghi_content_remote_refresh', $source, $type, $remote_id]);
+    if (!$this->lock->acquire($lock_id, 300)) {
+      $this->logger->notice('Skipped remote refresh for @type @id because another worker is processing it.', [
+        '@type' => $type,
+        '@id' => $remote_id,
+      ]);
+      return;
+    }
+
+    try {
+      $node = $this->loadNode($source, $type, $remote_id);
+      if (!$node instanceof ContentBase) {
+        $this->logger->notice('Remote refresh skipped for missing local @type @id from @source.', [
+          '@type' => $type,
+          '@id' => $remote_id,
+          '@source' => $source,
+        ]);
+        return;
+      }
+
+      $content_manager = $this->managerFactory->getContentManager($node);
+      if (!$content_manager) {
+        return;
+      }
+
+      if (isset($data->status) && (int) $data->status === NodeInterface::NOT_PUBLISHED) {
+        $node->setUnpublished();
+      }
+      else {
+        $content_manager->updateNodeFromRemote($node);
+      }
+      // Let the scheduled migration reconcile the id map; doing it here would
+      // fetch the full remote export for every single webhook item.
+      $content_manager->saveContentNode($node, FALSE);
+
+      $this->logger->info('Refreshed local @type node @nid from remote id @remote_id.', [
+        '@type' => $type,
+        '@nid' => $node->id(),
+        '@remote_id' => $remote_id,
+      ]);
+    }
+    finally {
+      $this->lock->release($lock_id);
+    }
+  }
+
+  /**
+   * Load the local node for a remote item.
+   *
+   * @param string $source
+   *   The remote source id.
+   * @param string $type
+   *   The content type.
+   * @param int $remote_id
+   *   The remote content id.
+   *
+   * @return \Drupal\ghi_content\Entity\ContentBase|null
+   *   The local content node if found.
+   */
+  private function loadNode(string $source, string $type, int $remote_id): ?ContentBase {
+    $map = [
+      'article' => [
+        'bundle' => ArticleManager::ARTICLE_BUNDLE,
+        'field' => ArticleManager::REMOTE_ARTICLE_FIELD,
+        'id_column' => 'article_id',
+      ],
+      'document' => [
+        'bundle' => DocumentManager::DOCUMENT_BUNDLE,
+        'field' => DocumentManager::REMOTE_DOCUMENT_FIELD,
+        'id_column' => 'document_id',
+      ],
+    ];
+    if (!isset($map[$type])) {
+      return NULL;
+    }
+
+    $results = $this->entityTypeManager->getStorage('node')->loadByProperties([
+      'type' => $map[$type]['bundle'],
+      $map[$type]['field'] . '.remote_source' => $source,
+      $map[$type]['field'] . '.' . $map[$type]['id_column'] => $remote_id,
+    ]);
+    $node = $results ? reset($results) : NULL;
+    return $node instanceof ContentBase ? $node : NULL;
+  }
+
+}

--- a/html/modules/custom/ghi_content/src/Plugin/QueueWorker/RemoteRefreshQueue.php
+++ b/html/modules/custom/ghi_content/src/Plugin/QueueWorker/RemoteRefreshQueue.php
@@ -4,11 +4,12 @@ namespace Drupal\ghi_content\Plugin\QueueWorker;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\Attribute\QueueWorker;
+use Drupal\Core\Queue\DelayedRequeueException;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\ghi_content\ContentManager\ArticleManager;
-use Drupal\ghi_content\ContentManager\DocumentManager;
+use Drupal\ghi_content\ContentManager\BaseContentManager;
 use Drupal\ghi_content\Entity\ContentBase;
+use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -23,11 +24,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFactoryPluginInterface {
 
   /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   * Delay before retrying when a matching migration is temporarily busy.
    */
-  protected $entityTypeManager;
+  private const MIGRATION_BUSY_RETRY_DELAY = 300;
+
+  /**
+   * Maximum time to keep retrying while a matching migration is busy.
+   */
+  private const MIGRATION_BUSY_MAX_RETRY_AGE = 21600;
 
   /**
    * The content manager factory.
@@ -35,6 +39,27 @@ final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFacto
    * @var \Drupal\ghi_content\ContentManager\ManagerFactory
    */
   protected $managerFactory;
+
+  /**
+   * The migration plugin manager.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationPluginManagerInterface
+   */
+  protected $migrationPluginManager;
+
+  /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $time;
+
+  /**
+   * The targeted migration importer.
+   *
+   * @var \Drupal\ghi_content\Import\TargetedMigrationImporter
+   */
+  protected $targetedMigrationImporter;
 
   /**
    * The lock backend.
@@ -55,8 +80,10 @@ final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFacto
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = new static($configuration, $plugin_id, $plugin_definition);
-    $instance->entityTypeManager = $container->get('entity_type.manager');
     $instance->managerFactory = $container->get('ghi_content.manager.factory');
+    $instance->migrationPluginManager = $container->get('plugin.manager.migration');
+    $instance->time = $container->get('datetime.time');
+    $instance->targetedMigrationImporter = $container->get('ghi_content.targeted_migration_importer');
     $instance->lock = $container->get('lock');
     $instance->logger = $container->get('logger.channel.ghi_content');
     return $instance;
@@ -70,11 +97,15 @@ final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFacto
     $type = $data->type ?? NULL;
     $remote_id = isset($data->id) ? (int) $data->id : NULL;
     $event = $data->event ?? 'unknown';
+    $received = isset($data->received) ? (int) $data->received : NULL;
     if (!$source || !$type || !$remote_id) {
       return;
     }
 
     $lock_id = implode(':', ['ghi_content_remote_refresh', $source, $type, $remote_id]);
+    // Keep updates for the same remote item serialized. A webhook can arrive
+    // while cron is also importing or while another delivery for the same item
+    // is still being processed.
     if (!$this->lock->acquire($lock_id, 300)) {
       $this->logger->notice('Skipped remote refresh for @type @id because another worker is processing it.', [
         '@type' => $type,
@@ -84,30 +115,15 @@ final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFacto
     }
 
     try {
-      $node = $this->loadNode($source, $type, $remote_id);
+      $remote_item_is_published = !isset($data->status) || (int) $data->status !== NodeInterface::NOT_PUBLISHED;
+      $node = $this->getOrImportLocalNode($source, $type, $remote_id, $event, $remote_item_is_published, $received);
       if (!$node instanceof ContentBase) {
-        $this->logger->notice('Remote refresh skipped for missing local @type @id from @source.', [
-          '@type' => $type,
-          '@id' => $remote_id,
-          '@source' => $source,
-        ]);
         return;
       }
 
-      $content_manager = $this->managerFactory->getContentManager($node);
-      if (!$content_manager) {
+      if (!$this->applyRemoteRefresh($node, $remote_item_is_published)) {
         return;
       }
-
-      if (isset($data->status) && (int) $data->status === NodeInterface::NOT_PUBLISHED) {
-        $node->setUnpublished();
-      }
-      else {
-        $content_manager->updateNodeFromRemote($node);
-      }
-      // Let the scheduled migration reconcile the id map; doing it here would
-      // fetch the full remote export for every single webhook item.
-      $content_manager->saveContentNode($node, FALSE);
 
       $this->logger->info('Processed @event event for local @type node @nid from remote source @source with remote id @remote_id.', [
         '@event' => $event,
@@ -123,6 +139,41 @@ final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFacto
   }
 
   /**
+   * Load an existing node or import it when the remote item is published.
+   *
+   * @param string $source
+   *   The remote source id.
+   * @param string $type
+   *   The content type.
+   * @param int $remote_id
+   *   The remote content id.
+   * @param string $event
+   *   The remote event name.
+   * @param bool $remote_item_is_published
+   *   Whether the remote item is currently published.
+   * @param int|null $received
+   *   The time when the queue item was first received.
+   *
+   * @return \Drupal\ghi_content\Entity\ContentBase|null
+   *   The local content node if one exists or could be imported.
+   */
+  private function getOrImportLocalNode(string $source, string $type, int $remote_id, string $event, bool $remote_item_is_published, ?int $received): ?ContentBase {
+    $node = $this->loadLocalNode($source, $type, $remote_id);
+    if ($node instanceof ContentBase) {
+      return $node;
+    }
+
+    if (!$remote_item_is_published) {
+      // Missing deleted or trashed content should not be created locally just
+      // to process an event whose outcome is "not published in HA".
+      $this->logMissingNodeSkipped($source, $type, $remote_id, 'the remote item is not published');
+      return NULL;
+    }
+
+    return $this->importMissingLocalNode($source, $type, $remote_id, $event, $received);
+  }
+
+  /**
    * Load the local node for a remote item.
    *
    * @param string $source
@@ -131,34 +182,211 @@ final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFacto
    *   The content type.
    * @param int $remote_id
    *   The remote content id.
+   * @param bool $reload
+   *   Whether to bypass a cached lookup result for this remote item.
    *
    * @return \Drupal\ghi_content\Entity\ContentBase|null
    *   The local content node if found.
    */
-  private function loadNode(string $source, string $type, int $remote_id): ?ContentBase {
-    $map = [
-      'article' => [
-        'bundle' => ArticleManager::ARTICLE_BUNDLE,
-        'field' => ArticleManager::REMOTE_ARTICLE_FIELD,
-        'id_column' => 'article_id',
-      ],
-      'document' => [
-        'bundle' => DocumentManager::DOCUMENT_BUNDLE,
-        'field' => DocumentManager::REMOTE_DOCUMENT_FIELD,
-        'id_column' => 'document_id',
-      ],
-    ];
-    if (!isset($map[$type])) {
+  private function loadLocalNode(string $source, string $type, int $remote_id, bool $reload = FALSE): ?ContentBase {
+    $content_manager = $this->managerFactory->getContentManagerForRemoteType($type);
+    if (!$content_manager) {
       return NULL;
     }
 
-    $results = $this->entityTypeManager->getStorage('node')->loadByProperties([
-      'type' => $map[$type]['bundle'],
-      $map[$type]['field'] . '.remote_source' => $source,
-      $map[$type]['field'] . '.' . $map[$type]['id_column'] => $remote_id,
-    ]);
-    $node = $results ? reset($results) : NULL;
+    // The content manager owns the bundle and remote-id field details. Keeping
+    // that lookup there prevents this queue worker from knowing about
+    // source-specific field names.
+    $nodes = $content_manager->loadNodesForRemoteIds($source, [$remote_id], $reload);
+    $node = $nodes ? reset($nodes) : NULL;
     return $node instanceof ContentBase ? $node : NULL;
+  }
+
+  /**
+   * Apply the remote refresh to the local node.
+   *
+   * @param \Drupal\ghi_content\Entity\ContentBase $node
+   *   The local content node.
+   * @param bool $remote_item_is_published
+   *   Whether the remote item is currently published.
+   *
+   * @return bool
+   *   TRUE if the refresh was applied, FALSE otherwise.
+   */
+  private function applyRemoteRefresh(ContentBase $node, bool $remote_item_is_published): bool {
+    $content_manager = $this->managerFactory->getContentManager($node);
+    if (!$content_manager instanceof BaseContentManager) {
+      $this->logger->warning('Remote refresh skipped local node @nid because no content manager was found.', [
+        '@nid' => $node->id(),
+      ]);
+      return FALSE;
+    }
+
+    if (!$remote_item_is_published) {
+      $node->setUnpublished();
+    }
+    else {
+      // For saved events we refresh the already-linked local node from the
+      // remote source. For deleted or trashed events CM sends status 0, so
+      // those events intentionally take the unpublished path above.
+      if (!$content_manager->updateNodeFromRemote($node)) {
+        $this->logger->warning('Remote refresh skipped local node @nid because remote data could not be loaded.', [
+          '@nid' => $node->id(),
+        ]);
+        return FALSE;
+      }
+    }
+
+    // Let the scheduled migration reconcile the id map; doing it here would
+    // fetch the full remote export for every single webhook item.
+    $content_manager->saveContentNode($node, FALSE);
+    return TRUE;
+  }
+
+  /**
+   * Import a missing local node.
+   *
+   * @param string $source
+   *   The remote source id.
+   * @param string $type
+   *   The content type.
+   * @param int $remote_id
+   *   The remote content id.
+   * @param string $event
+   *   The remote event name.
+   * @param int|null $received
+   *   The time when the queue item was first received.
+   *
+   * @return \Drupal\ghi_content\Entity\ContentBase|null
+   *   The imported local content node if one could be created.
+   */
+  private function importMissingLocalNode(string $source, string $type, int $remote_id, string $event, ?int $received): ?ContentBase {
+    $migration = $this->getImportMigration($source, $type);
+    if (!$migration instanceof MigrationInterface) {
+      // Without a matching migration we do not know how to create the local
+      // node while preserving the normal import mappings.
+      $this->logMissingNodeSkipped($source, $type, $remote_id, 'no matching import migration was found');
+      return NULL;
+    }
+
+    if ($migration->getStatus() !== MigrationInterface::STATUS_IDLE) {
+      if (!$this->shouldRetryBusyMigration($received)) {
+        $this->logger->error('Remote refresh stopped retrying local @type @id from @source because the migration stayed busy for too long.', [
+          '@type' => $type,
+          '@id' => $remote_id,
+          '@source' => $source,
+        ]);
+        return NULL;
+      }
+
+      // A busy migration is transient. Delay the queue item instead of marking
+      // it processed so the webhook can still create the missing node later.
+      $this->logger->notice('Delayed remote refresh creating local @type @id from @source because the migration is not idle.', [
+        '@type' => $type,
+        '@id' => $remote_id,
+        '@source' => $source,
+      ]);
+      throw new DelayedRequeueException(self::MIGRATION_BUSY_RETRY_DELAY);
+    }
+
+    if (!$this->targetedMigrationImporter->import($migration, $remote_id)) {
+      $this->logger->error('Remote refresh failed to import missing local @type @id from @source.', [
+        '@type' => $type,
+        '@id' => $remote_id,
+        '@source' => $source,
+      ]);
+      return NULL;
+    }
+
+    // The first lookup in this request may have cached the remote id as
+    // missing. Force a fresh lookup before checking whether the targeted import
+    // has created the node.
+    $node = $this->loadLocalNode($source, $type, $remote_id, TRUE);
+    if ($node instanceof ContentBase) {
+      $this->logger->info('Created local @type node @nid from @event event from remote source @source with remote id @remote_id.', [
+        '@type' => $type,
+        '@nid' => $node->id(),
+        '@event' => $event,
+        '@source' => $source,
+        '@remote_id' => $remote_id,
+      ]);
+    }
+    else {
+      $this->logger->error('Remote refresh import completed but no local @type node was found for remote source @source with remote id @remote_id.', [
+        '@type' => $type,
+        '@source' => $source,
+        '@remote_id' => $remote_id,
+      ]);
+    }
+    return $node;
+  }
+
+  /**
+   * Decide whether to keep retrying an item blocked by a busy migration.
+   *
+   * @param int|null $received
+   *   The time when the queue item was first received.
+   *
+   * @return bool
+   *   TRUE if the item should be delayed and retried.
+   */
+  private function shouldRetryBusyMigration(?int $received): bool {
+    if (!$received) {
+      return TRUE;
+    }
+    return $this->time->getRequestTime() - $received < self::MIGRATION_BUSY_MAX_RETRY_AGE;
+  }
+
+  /**
+   * Get the migration for a remote refresh item.
+   *
+   * @param string $source
+   *   The remote source id.
+   * @param string $type
+   *   The content type.
+   *
+   * @return \Drupal\migrate\Plugin\MigrationInterface|null
+   *   The migration or NULL if no matching import exists.
+   */
+  private function getImportMigration(string $source, string $type): ?MigrationInterface {
+    foreach ($this->migrationPluginManager->getDefinitions() as $migration_id => $definition) {
+      $source_configuration = $definition['source'] ?? [];
+      if (($source_configuration['remote_source'] ?? NULL) !== $source) {
+        continue;
+      }
+      if (($source_configuration['content_type'] ?? NULL) !== $type) {
+        continue;
+      }
+
+      // Use the migration metadata instead of hard-coding source-specific
+      // migration ids here. Adding another remote source should only require a
+      // matching migration definition and content manager support for the type.
+      /** @var \Drupal\migrate\Plugin\MigrationInterface|null $migration */
+      $migration = $this->migrationPluginManager->createInstance($migration_id);
+      return $migration instanceof MigrationInterface ? $migration : NULL;
+    }
+    return NULL;
+  }
+
+  /**
+   * Log that a remote refresh item cannot be applied without a local node.
+   *
+   * @param string $source
+   *   The remote source id.
+   * @param string $type
+   *   The content type.
+   * @param int $remote_id
+   *   The remote content id.
+   * @param string $reason
+   *   The reason why the item cannot be applied.
+   */
+  private function logMissingNodeSkipped(string $source, string $type, int $remote_id, string $reason): void {
+    $this->logger->notice('Remote refresh skipped for missing local @type @id from @source because @reason.', [
+      '@type' => $type,
+      '@id' => $remote_id,
+      '@source' => $source,
+      '@reason' => $reason,
+    ]);
   }
 
 }

--- a/html/modules/custom/ghi_content/src/Plugin/QueueWorker/RemoteRefreshQueue.php
+++ b/html/modules/custom/ghi_content/src/Plugin/QueueWorker/RemoteRefreshQueue.php
@@ -69,6 +69,7 @@ final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFacto
     $source = $data->source ?? NULL;
     $type = $data->type ?? NULL;
     $remote_id = isset($data->id) ? (int) $data->id : NULL;
+    $event = $data->event ?? 'unknown';
     if (!$source || !$type || !$remote_id) {
       return;
     }
@@ -108,9 +109,11 @@ final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFacto
       // fetch the full remote export for every single webhook item.
       $content_manager->saveContentNode($node, FALSE);
 
-      $this->logger->info('Refreshed local @type node @nid from remote id @remote_id.', [
+      $this->logger->info('Processed @event event for local @type node @nid from remote source @source with remote id @remote_id.', [
+        '@event' => $event,
         '@type' => $type,
         '@nid' => $node->id(),
+        '@source' => $source,
         '@remote_id' => $remote_id,
       ]);
     }

--- a/html/modules/custom/ghi_content/src/Plugin/QueueWorker/RemoteRefreshQueue.php
+++ b/html/modules/custom/ghi_content/src/Plugin/QueueWorker/RemoteRefreshQueue.php
@@ -10,7 +10,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\ghi_content\ContentManager\BaseContentManager;
 use Drupal\ghi_content\Entity\ContentBase;
 use Drupal\migrate\Plugin\MigrationInterface;
-use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -115,7 +114,7 @@ final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFacto
     }
 
     try {
-      $remote_item_is_published = !isset($data->status) || (int) $data->status !== NodeInterface::NOT_PUBLISHED;
+      $remote_item_is_published = !in_array($event, ['deleted', 'trashed'], TRUE);
       $node = $this->getOrImportLocalNode($source, $type, $remote_id, $event, $remote_item_is_published, $received);
       if (!$node instanceof ContentBase) {
         return;
@@ -227,8 +226,8 @@ final class RemoteRefreshQueue extends QueueWorkerBase implements ContainerFacto
     }
     else {
       // For saved events we refresh the already-linked local node from the
-      // remote source. For deleted or trashed events CM sends status 0, so
-      // those events intentionally take the unpublished path above.
+      // remote source. Deleted or trashed events intentionally take the
+      // unpublished path above.
       if (!$content_manager->updateNodeFromRemote($node)) {
         $this->logger->warning('Remote refresh skipped local node @nid because remote data could not be loaded.', [
           '@nid' => $node->id(),

--- a/html/modules/custom/ghi_content/src/Plugin/RemoteSource/HpcContentModule.php
+++ b/html/modules/custom/ghi_content/src/Plugin/RemoteSource/HpcContentModule.php
@@ -18,6 +18,8 @@ class HpcContentModule extends RemoteSourceBaseHpcContentModule implements Remot
 
   /**
    * {@inheritdoc}
+   *
+   * @see ghi_content.remote_sources.hpc_content_module
    */
   public function defaultConfiguration() {
     return [
@@ -25,6 +27,11 @@ class HpcContentModule extends RemoteSourceBaseHpcContentModule implements Remot
       'basic_auth' => NULL,
       'endpoint' => 'ncms',
       'access_key' => NULL,
+      'remote_refresh' => [
+        'webhook_secret' => NULL,
+        'signature_ttl' => 300,
+        'max_body_size' => 4096,
+      ],
     ];
   }
 

--- a/html/modules/custom/ghi_content/src/RemoteSource/RemoteRefreshSourceInterface.php
+++ b/html/modules/custom/ghi_content/src/RemoteSource/RemoteRefreshSourceInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\ghi_content\RemoteSource;
+
+/**
+ * Provides remote refresh settings for a remote source.
+ */
+interface RemoteRefreshSourceInterface {
+
+  /**
+   * Get the shared secret used to verify refresh notifications.
+   *
+   * @return string|null
+   *   The shared secret or NULL if none is configured.
+   */
+  public function getRemoteRefreshWebhookSecret(): ?string;
+
+  /**
+   * Get the maximum age for signed refresh notifications.
+   *
+   * @return int
+   *   The maximum age in seconds.
+   */
+  public function getRemoteRefreshSignatureTtl(): int;
+
+  /**
+   * Get the maximum allowed refresh notification body size.
+   *
+   * @return int
+   *   The maximum body size in bytes.
+   */
+  public function getRemoteRefreshMaxBodySize(): int;
+
+}

--- a/html/modules/custom/ghi_content/src/RemoteSource/RemoteSourceBaseHpcContentModule.php
+++ b/html/modules/custom/ghi_content/src/RemoteSource/RemoteSourceBaseHpcContentModule.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\ghi_content\RemoteSource;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\ghi_content\RemoteContent\HpcContentModule\RemoteArticle;
@@ -551,6 +552,83 @@ abstract class RemoteSourceBaseHpcContentModule extends RemoteSourceBase impleme
         'absolute' => TRUE,
       ])->toString(),
       '#input' => FALSE,
+    ];
+    $form['remote_refresh']['documentation'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Webhook contract'),
+      '#description' => $this->t('Use this contract when configuring the remote system that sends refresh notifications.'),
+      '#open' => FALSE,
+    ];
+    $form['remote_refresh']['documentation']['summary'] = [
+      '#theme' => 'item_list',
+      '#items' => [
+        $this->t('Send requests with the POST method to the refresh endpoint shown above.'),
+        $this->t('Include X-NCMS-Timestamp as a Unix timestamp in seconds. The timestamp must be within the configured signature time to live.'),
+        $this->t('Include X-NCMS-Signature as sha256=&lt;hex digest&gt;. The digest is an HMAC-SHA256 signature of &lt;timestamp&gt;.&lt;raw request body&gt; using the configured webhook secret.'),
+        $this->t('Use a new deliveryId UUID for each delivery. Duplicate delivery ids are accepted but are not queued again.'),
+      ],
+    ];
+    $form['remote_refresh']['documentation']['payload'] = [
+      '#type' => 'table',
+      '#header' => [
+        $this->t('Payload field'),
+        $this->t('Required'),
+        $this->t('Description'),
+      ],
+      '#rows' => [
+        [
+          ['data' => 'source'],
+          ['data' => $this->t('Yes')],
+          ['data' => $this->t('Remote source id, for example hpc_content_module.')],
+        ],
+        [
+          ['data' => 'type'],
+          ['data' => $this->t('Yes')],
+          ['data' => $this->t('Remote content type. Supported values are article and document.')],
+        ],
+        [
+          ['data' => 'id'],
+          ['data' => $this->t('Yes')],
+          ['data' => $this->t('Remote content id.')],
+        ],
+        [
+          ['data' => 'deliveryId'],
+          ['data' => $this->t('Yes')],
+          ['data' => $this->t('Unique UUID used for replay protection.')],
+        ],
+        [
+          ['data' => 'event'],
+          ['data' => $this->t('Yes')],
+          ['data' => $this->t('Supported values are saved, trashed, deleted, and ping.')],
+        ],
+        [
+          ['data' => 'changed'],
+          ['data' => $this->t('No')],
+          ['data' => $this->t('Unix timestamp for the remote content change.')],
+        ],
+      ],
+    ];
+    $form['remote_refresh']['documentation']['responses'] = [
+      '#theme' => 'item_list',
+      '#title' => $this->t('Responses'),
+      '#items' => [
+        $this->t('202 with queued=true: the notification was accepted and queued.'),
+        $this->t('202 with checked=true: a ping was accepted.'),
+        $this->t('202 with queued=false: the delivery id was already seen.'),
+        $this->t('400, 403, or 413: the payload, signature, or request size was rejected.'),
+      ],
+    ];
+    $example_payload = json_encode([
+      'source' => 'hpc_content_module',
+      'type' => 'article',
+      'id' => 123,
+      'event' => 'saved',
+      'deliveryId' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    $form['remote_refresh']['documentation']['example'] = [
+      '#type' => 'item',
+      '#title' => $this->t('Example payload'),
+      '#markup' => '<pre><code>' . Html::escape($example_payload) . '</code></pre>',
     ];
     $form['remote_refresh']['webhook_secret'] = [
       '#type' => 'password',

--- a/html/modules/custom/ghi_content/src/RemoteSource/RemoteSourceBaseHpcContentModule.php
+++ b/html/modules/custom/ghi_content/src/RemoteSource/RemoteSourceBaseHpcContentModule.php
@@ -24,6 +24,15 @@ use Symfony\Component\HttpFoundation\Response;
  */
 abstract class RemoteSourceBaseHpcContentModule extends RemoteSourceBase implements RemoteRefreshSourceInterface {
 
+  /**
+   * Remote refresh setting keys stored in plugin configuration.
+   */
+  const REMOTE_REFRESH_SETTING_KEYS = [
+    'webhook_secret',
+    'signature_ttl',
+    'max_body_size',
+  ];
+
   use SimpleCacheTrait;
 
   /**
@@ -415,35 +424,53 @@ abstract class RemoteSourceBaseHpcContentModule extends RemoteSourceBase impleme
   }
 
   /**
-   * Get the remote refresh settings for the remote source.
-   */
-  protected function getRemoteRefreshSettings(): array {
-    $config = $this->getConfiguration();
-    return $config['remote_refresh'] ?? [];
-  }
-
-  /**
    * {@inheritdoc}
    */
   public function getRemoteRefreshWebhookSecret(): ?string {
-    $remote_refresh = $this->getRemoteRefreshSettings();
-    return $remote_refresh['webhook_secret'] ?? NULL;
+    return $this->getRuntimeRemoteRefreshSetting('webhook_secret');
   }
 
   /**
    * {@inheritdoc}
    */
   public function getRemoteRefreshSignatureTtl(): int {
-    $remote_refresh = $this->getRemoteRefreshSettings();
-    return (int) ($remote_refresh['signature_ttl'] ?? 300);
+    return (int) $this->getRuntimeRemoteRefreshSetting('signature_ttl', 300);
   }
 
   /**
    * {@inheritdoc}
    */
   public function getRemoteRefreshMaxBodySize(): int {
-    $remote_refresh = $this->getRemoteRefreshSettings();
-    return (int) ($remote_refresh['max_body_size'] ?? 4096);
+    return (int) $this->getRuntimeRemoteRefreshSetting('max_body_size', 4096);
+  }
+
+  /**
+   * Get the stored remote refresh settings for the remote source.
+   */
+  protected function getStoredRemoteRefreshSettings(): array {
+    return $this->getConfiguration()['remote_refresh'] ?? [];
+  }
+
+  /**
+   * Get the remote refresh setting value that is active at runtime.
+   *
+   * Values returned by the config factory include file-based overrides from
+   * settings.php. Those overrides must win over the stored plugin
+   * configuration because webhook validation uses the runtime configuration,
+   * not necessarily the raw values visible in the remote source edit form.
+   *
+   * @param string $key
+   *   The remote refresh setting key.
+   * @param mixed $default
+   *   The default value to use when neither runtime config nor stored plugin
+   *   configuration provides this setting.
+   *
+   * @return mixed
+   *   The runtime remote refresh setting value.
+   */
+  private function getRuntimeRemoteRefreshSetting(string $key, $default = NULL) {
+    return $this->getRemoteRefreshConfigOverride($key)
+      ?? ($this->getConfiguration()['remote_refresh'][$key] ?? $default);
   }
 
   /**
@@ -509,7 +536,7 @@ abstract class RemoteSourceBaseHpcContentModule extends RemoteSourceBase impleme
       '#default_value' => $basic_auth['pass'] ?? NULL,
     ];
 
-    $remote_refresh = $this->getRemoteRefreshSettings();
+    $remote_refresh = $this->getStoredRemoteRefreshSettings();
     $form['remote_refresh'] = [
       '#type' => 'details',
       '#title' => $this->t('Remote refresh'),
@@ -558,16 +585,55 @@ abstract class RemoteSourceBaseHpcContentModule extends RemoteSourceBase impleme
    * {@inheritdoc}
    */
   public function setConfiguration(array $configuration) {
+    // $configuration is the plugin configuration built from the submitted
+    // form. It contains raw submitted values, not the runtime config values
+    // from settings.php overrides.
     if (empty($configuration['access_key']) && !empty($this->getRemoteAccessKey())) {
       $configuration['access_key'] = $this->getRemoteAccessKey();
     }
-    if (empty($configuration['remote_refresh']['webhook_secret'])) {
-      $remote_refresh = $this->getRemoteRefreshSettings();
-      if (!empty($remote_refresh['webhook_secret'])) {
-        $configuration['remote_refresh']['webhook_secret'] = $remote_refresh['webhook_secret'];
-      }
+    $stored_webhook_secret = $this->getStoredRemoteRefreshSettings()['webhook_secret'] ?? NULL;
+    if (empty($configuration['remote_refresh']['webhook_secret']) && !empty($stored_webhook_secret)) {
+      // The password element intentionally renders empty, so an unchanged
+      // webhook secret is submitted as an empty value. Restore the stored
+      // plugin configuration value before saving, otherwise the empty password
+      // submission would be treated as an intentional deletion.
+      $configuration['remote_refresh']['webhook_secret'] = $stored_webhook_secret;
     }
     parent::setConfiguration($configuration);
+  }
+
+  /**
+   * Get a file-based config override for a remote refresh setting.
+   *
+   * This intentionally returns only the value supplied by Drupal's runtime
+   * config system, for example from settings.php. Call
+   * getRuntimeRemoteRefreshSetting() when the final usable value is needed,
+   * because that method falls back to stored plugin configuration and defaults.
+   *
+   * @param string $key
+   *   The remote refresh setting key.
+   *
+   * @return mixed
+   *   The overridden remote refresh setting value, or NULL when no override is
+   *   active for this setting.
+   */
+  private function getRemoteRefreshConfigOverride(string $key) {
+    return $this->configFactory
+      ->get('ghi_content.remote_sources')
+      ->get($this->getRemoteRefreshConfigKey($key));
+  }
+
+  /**
+   * Get the config key for a remote refresh setting.
+   *
+   * @param string $key
+   *   The remote refresh setting key.
+   *
+   * @return string
+   *   The config key.
+   */
+  private function getRemoteRefreshConfigKey(string $key): string {
+    return $this->getPluginId() . '.remote_refresh.' . $key;
   }
 
   /**
@@ -584,6 +650,7 @@ abstract class RemoteSourceBaseHpcContentModule extends RemoteSourceBase impleme
    * {@inheritdoc}
    */
   public function getFileSize($uri) {
+    $options = [];
     if ($basic_auth = $this->getRemoteBasicAuth()) {
       $options[RequestOptions::AUTH] = [
         $basic_auth['user'],

--- a/html/modules/custom/ghi_content/src/RemoteSource/RemoteSourceBaseHpcContentModule.php
+++ b/html/modules/custom/ghi_content/src/RemoteSource/RemoteSourceBaseHpcContentModule.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * HPC Content Module specific remote source base class.
  */
-abstract class RemoteSourceBaseHpcContentModule extends RemoteSourceBase {
+abstract class RemoteSourceBaseHpcContentModule extends RemoteSourceBase implements RemoteRefreshSourceInterface {
 
   use SimpleCacheTrait;
 
@@ -415,6 +415,38 @@ abstract class RemoteSourceBaseHpcContentModule extends RemoteSourceBase {
   }
 
   /**
+   * Get the remote refresh settings for the remote source.
+   */
+  protected function getRemoteRefreshSettings(): array {
+    $config = $this->getConfiguration();
+    return $config['remote_refresh'] ?? [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRemoteRefreshWebhookSecret(): ?string {
+    $remote_refresh = $this->getRemoteRefreshSettings();
+    return $remote_refresh['webhook_secret'] ?? NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRemoteRefreshSignatureTtl(): int {
+    $remote_refresh = $this->getRemoteRefreshSettings();
+    return (int) ($remote_refresh['signature_ttl'] ?? 300);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRemoteRefreshMaxBodySize(): int {
+    $remote_refresh = $this->getRemoteRefreshSettings();
+    return (int) ($remote_refresh['max_body_size'] ?? 4096);
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function checkConnection() {
@@ -477,6 +509,48 @@ abstract class RemoteSourceBaseHpcContentModule extends RemoteSourceBase {
       '#default_value' => $basic_auth['pass'] ?? NULL,
     ];
 
+    $remote_refresh = $this->getRemoteRefreshSettings();
+    $form['remote_refresh'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Remote refresh'),
+      '#description' => $this->t('Settings for signed refresh notifications sent by this remote source.'),
+      '#open' => !empty($remote_refresh['webhook_secret']),
+      '#tree' => TRUE,
+    ];
+    $form['remote_refresh']['endpoint'] = [
+      '#type' => 'item',
+      '#title' => $this->t('Refresh endpoint'),
+      '#markup' => Url::fromRoute('ghi_content.remote_refresh.webhook', [], [
+        'absolute' => TRUE,
+      ])->toString(),
+      '#input' => FALSE,
+    ];
+    $form['remote_refresh']['webhook_secret'] = [
+      '#type' => 'password',
+      '#title' => $this->t('Webhook secret'),
+      '#description' => $this->t('Enter the shared secret used to validate refresh notifications from this remote source. No webhook secret is currently set.'),
+      '#default_value' => $remote_refresh['webhook_secret'] ?? NULL,
+    ];
+    if (!empty($remote_refresh['webhook_secret'])) {
+      $form['remote_refresh']['webhook_secret']['#description'] = $this->t('Enter the shared secret used to validate refresh notifications from this remote source. A webhook secret is currently set. Enter a new value to replace it, or leave this field empty to keep the current one.');
+    }
+    $form['remote_refresh']['signature_ttl'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Signature time to live'),
+      '#description' => $this->t('Maximum age in seconds for signed refresh notifications.'),
+      '#default_value' => $remote_refresh['signature_ttl'] ?? 300,
+      '#min' => 1,
+      '#required' => TRUE,
+    ];
+    $form['remote_refresh']['max_body_size'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Maximum body size'),
+      '#description' => $this->t('Maximum request body size in bytes for refresh notifications.'),
+      '#default_value' => $remote_refresh['max_body_size'] ?? 4096,
+      '#min' => 1,
+      '#required' => TRUE,
+    ];
+
     return $form;
   }
 
@@ -486,6 +560,12 @@ abstract class RemoteSourceBaseHpcContentModule extends RemoteSourceBase {
   public function setConfiguration(array $configuration) {
     if (empty($configuration['access_key']) && !empty($this->getRemoteAccessKey())) {
       $configuration['access_key'] = $this->getRemoteAccessKey();
+    }
+    if (empty($configuration['remote_refresh']['webhook_secret'])) {
+      $remote_refresh = $this->getRemoteRefreshSettings();
+      if (!empty($remote_refresh['webhook_secret'])) {
+        $configuration['remote_refresh']['webhook_secret'] = $remote_refresh['webhook_secret'];
+      }
     }
     parent::setConfiguration($configuration);
   }

--- a/html/modules/custom/ghi_content/tests/src/Unit/Controller/RemoteRefreshControllerTest.php
+++ b/html/modules/custom/ghi_content/tests/src/Unit/Controller/RemoteRefreshControllerTest.php
@@ -150,6 +150,31 @@ class RemoteRefreshControllerTest extends UnitTestCase {
   }
 
   /**
+   * Tests that ping requests are validated without queueing.
+   */
+  public function testPingRequestIsNotQueued() {
+    $secret = 'local-refresh-secret';
+    $payload = [
+      'source' => 'hpc_content_module',
+      'type' => 'article',
+      'id' => 1,
+      'event' => 'ping',
+      'deliveryId' => self::DELIVERY_ID,
+    ];
+    $body = json_encode($payload);
+    $request = $this->createSignedRequest($body, $secret);
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->never())->method('createItem');
+
+    $controller = $this->createController($secret, $queue);
+    $response = $controller->receive($request);
+
+    $this->assertSame(Response::HTTP_ACCEPTED, $response->getStatusCode());
+    $this->assertSame('{"checked":true}', $response->getContent());
+  }
+
+  /**
    * Tests that delivery ids are required.
    */
   public function testMissingDeliveryIdIsRejected() {

--- a/html/modules/custom/ghi_content/tests/src/Unit/Controller/RemoteRefreshControllerTest.php
+++ b/html/modules/custom/ghi_content/tests/src/Unit/Controller/RemoteRefreshControllerTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Drupal\Tests\ghi_content\Unit\Controller;
+
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueInterface;
+use Drupal\ghi_content\Controller\RemoteRefreshController;
+use Drupal\ghi_content\RemoteSource\RemoteRefreshSourceInterface;
+use Drupal\ghi_content\RemoteSource\RemoteSourceManager;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tests the remote refresh webhook controller.
+ *
+ * @group ghi_content
+ */
+class RemoteRefreshControllerTest extends UnitTestCase {
+
+  /**
+   * Tests that a valid signed notification is queued.
+   */
+  public function testValidRequestQueuesRefresh() {
+    $secret = 'local-refresh-secret';
+    $payload = [
+      'source' => 'hpc_content_module',
+      'type' => 'article',
+      'id' => 123,
+      'status' => 1,
+      'changed' => 1710000000,
+      'forceUpdate' => 1,
+      'event' => 'saved',
+    ];
+    $body = json_encode($payload);
+    $request = $this->createSignedRequest($body, $secret);
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->once())
+      ->method('createItem')
+      ->with($this->callback(function ($item) {
+        return $item->source === 'hpc_content_module'
+          && $item->type === 'article'
+          && $item->id === 123
+          && $item->status === 1
+          && $item->changed === 1710000000
+          && $item->force_update === 1
+          && $item->event === 'saved';
+      }));
+
+    $controller = $this->createController($secret, $queue);
+    $response = $controller->receive($request);
+
+    $this->assertSame(Response::HTTP_ACCEPTED, $response->getStatusCode());
+    $this->assertSame('{"queued":true}', $response->getContent());
+  }
+
+  /**
+   * Tests that any discovered remote source can send refresh notifications.
+   */
+  public function testValidRequestForDiscoveredSourceQueuesRefresh() {
+    $secret = 'secondary-secret';
+    $payload = [
+      'source' => 'secondary_source',
+      'type' => 'document',
+      'id' => 456,
+    ];
+    $body = json_encode($payload);
+    $request = $this->createSignedRequest($body, $secret);
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->once())
+      ->method('createItem')
+      ->with($this->callback(function ($item) {
+        return $item->source === 'secondary_source'
+          && $item->type === 'document'
+          && $item->id === 456;
+      }));
+
+    $controller = $this->createController($secret, $queue, 'secondary_source');
+    $response = $controller->receive($request);
+
+    $this->assertSame(Response::HTTP_ACCEPTED, $response->getStatusCode());
+  }
+
+  /**
+   * Tests that an invalid signature is rejected before queueing.
+   */
+  public function testInvalidSignatureIsRejected() {
+    $body = '{"source":"hpc_content_module","type":"article","id":123}';
+    $request = Request::create('/', 'POST', [], [], [], [], $body);
+    $request->headers->set('X-NCMS-Timestamp', (string) time());
+    $request->headers->set('X-NCMS-Signature', 'sha256=invalid');
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->never())->method('createItem');
+
+    $controller = $this->createController('local-refresh-secret', $queue);
+    $response = $controller->receive($request);
+
+    $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+  }
+
+  /**
+   * Tests that oversized requests are rejected before queueing.
+   */
+  public function testOversizedRequestIsRejected() {
+    $request = Request::create('/', 'POST', [], [], [], [], str_repeat('x', 4097));
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->never())->method('createItem');
+
+    $controller = $this->createController('local-refresh-secret', $queue);
+    $response = $controller->receive($request);
+
+    $this->assertSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, $response->getStatusCode());
+  }
+
+  /**
+   * Tests that old signed requests are rejected.
+   */
+  public function testExpiredSignatureIsRejected() {
+    $secret = 'local-refresh-secret';
+    $body = '{"source":"hpc_content_module","type":"article","id":123}';
+    $timestamp = (string) (time() - 301);
+    $signature = 'sha256=' . hash_hmac('sha256', $timestamp . '.' . $body, $secret);
+
+    $request = Request::create('/', 'POST', [], [], [], [], $body);
+    $request->headers->set('X-NCMS-Timestamp', $timestamp);
+    $request->headers->set('X-NCMS-Signature', $signature);
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->never())->method('createItem');
+
+    $controller = $this->createController($secret, $queue);
+    $response = $controller->receive($request);
+
+    $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+  }
+
+  /**
+   * Tests that invalid payloads are rejected after signature verification.
+   */
+  public function testInvalidPayloadIsRejected() {
+    $secret = 'local-refresh-secret';
+    $body = '{"source":"unknown","type":"article","id":123}';
+    $request = $this->createSignedRequest($body, $secret);
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->never())->method('createItem');
+
+    $controller = $this->createController($secret, $queue);
+    $response = $controller->receive($request);
+
+    $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+  }
+
+  /**
+   * Create the controller under test.
+   *
+   * @param string $secret
+   *   The configured shared secret.
+   * @param \Drupal\Core\Queue\QueueInterface $queue
+   *   The queue mock.
+   * @param string $source
+   *   The discovered remote source id.
+   *
+   * @return \Drupal\ghi_content\Controller\RemoteRefreshController
+   *   The controller.
+   */
+  private function createController(string $secret, QueueInterface $queue, string $source = 'hpc_content_module'): RemoteRefreshController {
+    $queue_factory = $this->createMock(QueueFactory::class);
+    $queue_factory->method('get')
+      ->with(RemoteRefreshController::QUEUE_ID)
+      ->willReturn($queue);
+
+    $remote_source = $this->createMock(RemoteRefreshSourceInterface::class);
+    $remote_source->method('getRemoteRefreshWebhookSecret')->willReturn($secret);
+    $remote_source->method('getRemoteRefreshSignatureTtl')->willReturn(300);
+    $remote_source->method('getRemoteRefreshMaxBodySize')->willReturn(4096);
+
+    $remote_source_manager = $this->createMock(RemoteSourceManager::class);
+    $remote_source_manager->method('getDefinitions')->willReturn([
+      $source => ['id' => $source],
+    ]);
+    $remote_source_manager->method('createInstance')
+      ->with($source)
+      ->willReturn($remote_source);
+
+    return new RemoteRefreshController($queue_factory, $remote_source_manager, new NullLogger());
+  }
+
+  /**
+   * Create a signed request for the given body.
+   *
+   * @param string $body
+   *   The raw request body.
+   * @param string $secret
+   *   The shared secret.
+   *
+   * @return \Symfony\Component\HttpFoundation\Request
+   *   The signed request.
+   */
+  private function createSignedRequest(string $body, string $secret): Request {
+    $timestamp = (string) time();
+    $signature = 'sha256=' . hash_hmac('sha256', $timestamp . '.' . $body, $secret);
+
+    $request = Request::create('/', 'POST', [], [], [], [], $body);
+    $request->headers->set('X-NCMS-Timestamp', $timestamp);
+    $request->headers->set('X-NCMS-Signature', $signature);
+    return $request;
+  }
+
+}

--- a/html/modules/custom/ghi_content/tests/src/Unit/Controller/RemoteRefreshControllerTest.php
+++ b/html/modules/custom/ghi_content/tests/src/Unit/Controller/RemoteRefreshControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\ghi_content\Unit\Controller;
 
+use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
+use Drupal\Core\KeyValueStore\KeyValueStoreExpirableInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueInterface;
 use Drupal\ghi_content\Controller\RemoteRefreshController;
@@ -20,6 +22,11 @@ use Symfony\Component\HttpFoundation\Response;
 class RemoteRefreshControllerTest extends UnitTestCase {
 
   /**
+   * A valid delivery id.
+   */
+  const DELIVERY_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+  /**
    * Tests that a valid signed notification is queued.
    */
   public function testValidRequestQueuesRefresh() {
@@ -32,6 +39,7 @@ class RemoteRefreshControllerTest extends UnitTestCase {
       'changed' => 1710000000,
       'forceUpdate' => 1,
       'event' => 'saved',
+      'deliveryId' => self::DELIVERY_ID,
     ];
     $body = json_encode($payload);
     $request = $this->createSignedRequest($body, $secret);
@@ -46,7 +54,8 @@ class RemoteRefreshControllerTest extends UnitTestCase {
           && $item->status === 1
           && $item->changed === 1710000000
           && $item->force_update === 1
-          && $item->event === 'saved';
+          && $item->event === 'saved'
+          && $item->delivery_id === self::DELIVERY_ID;
       }));
 
     $controller = $this->createController($secret, $queue);
@@ -65,6 +74,7 @@ class RemoteRefreshControllerTest extends UnitTestCase {
       'source' => 'secondary_source',
       'type' => 'document',
       'id' => 456,
+      'deliveryId' => self::DELIVERY_ID,
     ];
     $body = json_encode($payload);
     $request = $this->createSignedRequest($body, $secret);
@@ -85,10 +95,82 @@ class RemoteRefreshControllerTest extends UnitTestCase {
   }
 
   /**
+   * Tests that trashed notifications are queued.
+   */
+  public function testTrashedRequestQueuesRefresh() {
+    $secret = 'local-refresh-secret';
+    $payload = [
+      'source' => 'hpc_content_module',
+      'type' => 'article',
+      'id' => 123,
+      'status' => 0,
+      'event' => 'trashed',
+      'deliveryId' => self::DELIVERY_ID,
+    ];
+    $body = json_encode($payload);
+    $request = $this->createSignedRequest($body, $secret);
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->once())
+      ->method('createItem')
+      ->with($this->callback(function ($item) {
+        return $item->status === 0 && $item->event === 'trashed';
+      }));
+
+    $controller = $this->createController($secret, $queue);
+    $response = $controller->receive($request);
+
+    $this->assertSame(Response::HTTP_ACCEPTED, $response->getStatusCode());
+  }
+
+  /**
+   * Tests that duplicate deliveries are not queued again.
+   */
+  public function testDuplicateDeliveryIsNotQueued() {
+    $secret = 'local-refresh-secret';
+    $payload = [
+      'source' => 'hpc_content_module',
+      'type' => 'article',
+      'id' => 123,
+      'status' => 0,
+      'event' => 'deleted',
+      'deliveryId' => self::DELIVERY_ID,
+    ];
+    $body = json_encode($payload);
+    $request = $this->createSignedRequest($body, $secret);
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->never())->method('createItem');
+
+    $controller = $this->createController($secret, $queue, 'hpc_content_module', FALSE);
+    $response = $controller->receive($request);
+
+    $this->assertSame(Response::HTTP_ACCEPTED, $response->getStatusCode());
+    $this->assertSame('{"queued":false}', $response->getContent());
+  }
+
+  /**
+   * Tests that delivery ids are required.
+   */
+  public function testMissingDeliveryIdIsRejected() {
+    $secret = 'local-refresh-secret';
+    $body = '{"source":"hpc_content_module","type":"article","id":123}';
+    $request = $this->createSignedRequest($body, $secret);
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->never())->method('createItem');
+
+    $controller = $this->createController($secret, $queue);
+    $response = $controller->receive($request);
+
+    $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+  }
+
+  /**
    * Tests that an invalid signature is rejected before queueing.
    */
   public function testInvalidSignatureIsRejected() {
-    $body = '{"source":"hpc_content_module","type":"article","id":123}';
+    $body = '{"source":"hpc_content_module","type":"article","id":123,"deliveryId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}';
     $request = Request::create('/', 'POST', [], [], [], [], $body);
     $request->headers->set('X-NCMS-Timestamp', (string) time());
     $request->headers->set('X-NCMS-Signature', 'sha256=invalid');
@@ -122,7 +204,7 @@ class RemoteRefreshControllerTest extends UnitTestCase {
    */
   public function testExpiredSignatureIsRejected() {
     $secret = 'local-refresh-secret';
-    $body = '{"source":"hpc_content_module","type":"article","id":123}';
+    $body = '{"source":"hpc_content_module","type":"article","id":123,"deliveryId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}';
     $timestamp = (string) (time() - 301);
     $signature = 'sha256=' . hash_hmac('sha256', $timestamp . '.' . $body, $secret);
 
@@ -144,7 +226,7 @@ class RemoteRefreshControllerTest extends UnitTestCase {
    */
   public function testInvalidPayloadIsRejected() {
     $secret = 'local-refresh-secret';
-    $body = '{"source":"unknown","type":"article","id":123}';
+    $body = '{"source":"unknown","type":"article","id":123,"deliveryId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}';
     $request = $this->createSignedRequest($body, $secret);
 
     $queue = $this->createMock(QueueInterface::class);
@@ -165,11 +247,13 @@ class RemoteRefreshControllerTest extends UnitTestCase {
    *   The queue mock.
    * @param string $source
    *   The discovered remote source id.
+   * @param bool $claim_delivery
+   *   Whether the delivery id can be claimed.
    *
    * @return \Drupal\ghi_content\Controller\RemoteRefreshController
    *   The controller.
    */
-  private function createController(string $secret, QueueInterface $queue, string $source = 'hpc_content_module'): RemoteRefreshController {
+  private function createController(string $secret, QueueInterface $queue, string $source = 'hpc_content_module', bool $claim_delivery = TRUE): RemoteRefreshController {
     $queue_factory = $this->createMock(QueueFactory::class);
     $queue_factory->method('get')
       ->with(RemoteRefreshController::QUEUE_ID)
@@ -188,7 +272,15 @@ class RemoteRefreshControllerTest extends UnitTestCase {
       ->with($source)
       ->willReturn($remote_source);
 
-    return new RemoteRefreshController($queue_factory, $remote_source_manager, new NullLogger());
+    $delivery_store = $this->createMock(KeyValueStoreExpirableInterface::class);
+    $delivery_store->method('setWithExpireIfNotExists')->willReturn($claim_delivery);
+
+    $key_value_expirable_factory = $this->createMock(KeyValueExpirableFactoryInterface::class);
+    $key_value_expirable_factory->method('get')
+      ->with('ghi_content_remote_refresh_deliveries')
+      ->willReturn($delivery_store);
+
+    return new RemoteRefreshController($queue_factory, $remote_source_manager, $key_value_expirable_factory, new NullLogger());
   }
 
   /**

--- a/html/modules/custom/ghi_content/tests/src/Unit/Controller/RemoteRefreshControllerTest.php
+++ b/html/modules/custom/ghi_content/tests/src/Unit/Controller/RemoteRefreshControllerTest.php
@@ -35,9 +35,7 @@ class RemoteRefreshControllerTest extends UnitTestCase {
       'source' => 'hpc_content_module',
       'type' => 'article',
       'id' => 123,
-      'status' => 1,
       'changed' => 1710000000,
-      'forceUpdate' => 1,
       'event' => 'saved',
       'deliveryId' => self::DELIVERY_ID,
     ];
@@ -51,9 +49,7 @@ class RemoteRefreshControllerTest extends UnitTestCase {
         return $item->source === 'hpc_content_module'
           && $item->type === 'article'
           && $item->id === 123
-          && $item->status === 1
           && $item->changed === 1710000000
-          && $item->force_update === 1
           && $item->event === 'saved'
           && $item->delivery_id === self::DELIVERY_ID;
       }));
@@ -74,6 +70,7 @@ class RemoteRefreshControllerTest extends UnitTestCase {
       'source' => 'secondary_source',
       'type' => 'document',
       'id' => 456,
+      'event' => 'saved',
       'deliveryId' => self::DELIVERY_ID,
     ];
     $body = json_encode($payload);
@@ -103,7 +100,6 @@ class RemoteRefreshControllerTest extends UnitTestCase {
       'source' => 'hpc_content_module',
       'type' => 'article',
       'id' => 123,
-      'status' => 0,
       'event' => 'trashed',
       'deliveryId' => self::DELIVERY_ID,
     ];
@@ -114,7 +110,7 @@ class RemoteRefreshControllerTest extends UnitTestCase {
     $queue->expects($this->once())
       ->method('createItem')
       ->with($this->callback(function ($item) {
-        return $item->status === 0 && $item->event === 'trashed';
+        return $item->event === 'trashed';
       }));
 
     $controller = $this->createController($secret, $queue);
@@ -132,7 +128,6 @@ class RemoteRefreshControllerTest extends UnitTestCase {
       'source' => 'hpc_content_module',
       'type' => 'article',
       'id' => 123,
-      'status' => 0,
       'event' => 'deleted',
       'deliveryId' => self::DELIVERY_ID,
     ];
@@ -179,7 +174,24 @@ class RemoteRefreshControllerTest extends UnitTestCase {
    */
   public function testMissingDeliveryIdIsRejected() {
     $secret = 'local-refresh-secret';
-    $body = '{"source":"hpc_content_module","type":"article","id":123}';
+    $body = '{"source":"hpc_content_module","type":"article","id":123,"event":"saved"}';
+    $request = $this->createSignedRequest($body, $secret);
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->never())->method('createItem');
+
+    $controller = $this->createController($secret, $queue);
+    $response = $controller->receive($request);
+
+    $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+  }
+
+  /**
+   * Tests that event is required.
+   */
+  public function testMissingEventIsRejected() {
+    $secret = 'local-refresh-secret';
+    $body = '{"source":"hpc_content_module","type":"article","id":123,"deliveryId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}';
     $request = $this->createSignedRequest($body, $secret);
 
     $queue = $this->createMock(QueueInterface::class);
@@ -195,7 +207,7 @@ class RemoteRefreshControllerTest extends UnitTestCase {
    * Tests that an invalid signature is rejected before queueing.
    */
   public function testInvalidSignatureIsRejected() {
-    $body = '{"source":"hpc_content_module","type":"article","id":123,"deliveryId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}';
+    $body = '{"source":"hpc_content_module","type":"article","id":123,"event":"saved","deliveryId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}';
     $request = Request::create('/', 'POST', [], [], [], [], $body);
     $request->headers->set('X-NCMS-Timestamp', (string) time());
     $request->headers->set('X-NCMS-Signature', 'sha256=invalid');
@@ -229,7 +241,7 @@ class RemoteRefreshControllerTest extends UnitTestCase {
    */
   public function testExpiredSignatureIsRejected() {
     $secret = 'local-refresh-secret';
-    $body = '{"source":"hpc_content_module","type":"article","id":123,"deliveryId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}';
+    $body = '{"source":"hpc_content_module","type":"article","id":123,"event":"saved","deliveryId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}';
     $timestamp = (string) (time() - 301);
     $signature = 'sha256=' . hash_hmac('sha256', $timestamp . '.' . $body, $secret);
 

--- a/html/modules/custom/ghi_content/tests/src/Unit/Import/TargetedMigrationImporterTest.php
+++ b/html/modules/custom/ghi_content/tests/src/Unit/Import/TargetedMigrationImporterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\Tests\ghi_content\Unit\Import;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\ghi_content\Import\TargetedMigrationImporter;
+use Drupal\migrate\Plugin\MigrateIdMapInterface;
+use Drupal\migrate\Plugin\MigrateSourceInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests targeted migration imports.
+ *
+ * @group ghi_content
+ */
+class TargetedMigrationImporterTest extends UnitTestCase {
+
+  /**
+   * Tests that targeted update imports prepare the selected source id.
+   */
+  public function testTargetedImportMarksSelectedSourceIdForUpdate(): void {
+    $id_map = $this->createMock(MigrateIdMapInterface::class);
+    $id_map->expects($this->once())
+      ->method('setUpdate')
+      ->with(['id' => '123']);
+
+    $source = $this->createMock(MigrateSourceInterface::class);
+    $source->expects($this->once())
+      ->method('getIds')
+      ->willReturn(['id' => ['type' => 'integer']]);
+
+    $migration = $this->createMock(MigrationInterface::class);
+    $migration->expects($this->once())->method('getSourcePlugin')->willReturn($source);
+    $migration->method('getIdMap')->willReturn($id_map);
+    // Keep the executable from doing a full import. The important part for this
+    // test is that the importer mirrors migrate_tools' update preparation
+    // before control passes to the executable.
+    $migration->method('getStatus')->willReturn(MigrationInterface::STATUS_IMPORTING);
+    $migration->method('id')->willReturn('articles_hpc_content_module');
+    $migration->method('getStatusLabel')->willReturn('Importing');
+
+    $container = new ContainerBuilder();
+    $string_translation = $this->createMock(TranslationInterface::class);
+    $string_translation->method('translateString')->willReturnCallback(fn($string) => $string);
+    $logger_factory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $logger_factory->method('get')->willReturn(new NullLogger());
+    $container->set('event_dispatcher', new EventDispatcher());
+    $container->set('logger.factory', $logger_factory);
+    $container->set('string_translation', $string_translation);
+    \Drupal::setContainer($container);
+
+    $importer = new TargetedMigrationImporter(
+      $this->createMock(KeyValueFactoryInterface::class),
+      $this->createMock(TimeInterface::class),
+      $string_translation,
+    );
+
+    $error_reporting = error_reporting(E_ALL & ~E_DEPRECATED);
+    try {
+      $this->assertFalse($importer->import($migration, 123));
+    }
+    finally {
+      error_reporting($error_reporting);
+    }
+  }
+
+}

--- a/html/modules/custom/ghi_content/tests/src/Unit/Plugin/QueueWorker/RemoteRefreshQueueTest.php
+++ b/html/modules/custom/ghi_content/tests/src/Unit/Plugin/QueueWorker/RemoteRefreshQueueTest.php
@@ -2,13 +2,16 @@
 
 namespace Drupal\Tests\ghi_content\Unit\Plugin\QueueWorker;
 
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Lock\LockBackendInterface;
+use Drupal\Core\Queue\DelayedRequeueException;
 use Drupal\ghi_content\ContentManager\BaseContentManager;
 use Drupal\ghi_content\ContentManager\ManagerFactory;
 use Drupal\ghi_content\Entity\ContentBase;
+use Drupal\ghi_content\Import\TargetedMigrationImporter;
 use Drupal\ghi_content\Plugin\QueueWorker\RemoteRefreshQueue;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
 use Drupal\Tests\UnitTestCase;
 use Psr\Log\LoggerInterface;
 
@@ -27,17 +30,16 @@ class RemoteRefreshQueueTest extends UnitTestCase {
     $node->expects($this->once())->method('setUnpublished');
     $node->method('id')->willReturn(789);
 
-    $storage = $this->createMock(EntityStorageInterface::class);
-    $storage->method('loadByProperties')->willReturn([$node]);
-
-    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
-    $entity_type_manager->method('getStorage')->with('node')->willReturn($storage);
-
     $content_manager = $this->createMock(BaseContentManager::class);
+    $content_manager->expects($this->once())
+      ->method('loadNodesForRemoteIds')
+      ->with('hpc_content_module', [123])
+      ->willReturn([$node]);
     $content_manager->expects($this->never())->method('updateNodeFromRemote');
     $content_manager->expects($this->once())->method('saveContentNode')->with($node, FALSE);
 
     $manager_factory = $this->createMock(ManagerFactory::class);
+    $manager_factory->method('getContentManagerForRemoteType')->with('article')->willReturn($content_manager);
     $manager_factory->method('getContentManager')->with($node)->willReturn($content_manager);
 
     $lock = $this->createMock(LockBackendInterface::class);
@@ -59,7 +61,6 @@ class RemoteRefreshQueueTest extends UnitTestCase {
       );
 
     $worker = new RemoteRefreshQueue([], 'ghi_content_remote_refresh', []);
-    $this->setProtectedProperty($worker, 'entityTypeManager', $entity_type_manager);
     $this->setProtectedProperty($worker, 'managerFactory', $manager_factory);
     $this->setProtectedProperty($worker, 'lock', $lock);
     $this->setProtectedProperty($worker, 'logger', $logger);
@@ -70,6 +71,266 @@ class RemoteRefreshQueueTest extends UnitTestCase {
       'id' => 123,
       'status' => 0,
       'event' => 'deleted',
+    ]);
+  }
+
+  /**
+   * Tests that missing unpublished items are not imported.
+   */
+  public function testMissingUnpublishedItemIsSkipped(): void {
+    $content_manager = $this->createMock(BaseContentManager::class);
+    $content_manager->expects($this->once())
+      ->method('loadNodesForRemoteIds')
+      ->with('hpc_content_module', [123])
+      ->willReturn([]);
+
+    $manager_factory = $this->createMock(ManagerFactory::class);
+    $manager_factory->method('getContentManagerForRemoteType')->with('article')->willReturn($content_manager);
+    $manager_factory->expects($this->never())->method('getContentManager');
+
+    $lock = $this->createMock(LockBackendInterface::class);
+    $lock->method('acquire')->willReturn(TRUE);
+    $lock->expects($this->once())->method('release')->with('ghi_content_remote_refresh:hpc_content_module:article:123');
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('notice')
+      ->with(
+        'Remote refresh skipped for missing local @type @id from @source because @reason.',
+        [
+          '@type' => 'article',
+          '@id' => 123,
+          '@source' => 'hpc_content_module',
+          '@reason' => 'the remote item is not published',
+        ]
+      );
+    $logger->expects($this->never())->method('info');
+
+    $worker = new RemoteRefreshQueue([], 'ghi_content_remote_refresh', []);
+    $this->setProtectedProperty($worker, 'managerFactory', $manager_factory);
+    $this->setProtectedProperty($worker, 'lock', $lock);
+    $this->setProtectedProperty($worker, 'logger', $logger);
+
+    $worker->processItem((object) [
+      'source' => 'hpc_content_module',
+      'type' => 'article',
+      'id' => 123,
+      'status' => 0,
+      'event' => 'saved',
+    ]);
+  }
+
+  /**
+   * Tests that a missing published item is imported and processed.
+   */
+  public function testMissingPublishedItemIsImportedAndProcessed(): void {
+    $node = $this->createMock(ContentBase::class);
+    $node->method('id')->willReturn(789);
+
+    $content_manager = $this->createMock(BaseContentManager::class);
+    $content_manager->expects($this->exactly(2))
+      ->method('loadNodesForRemoteIds')
+      ->withConsecutive(
+        ['hpc_content_module', [123], FALSE],
+        ['hpc_content_module', [123], TRUE],
+      )
+      ->willReturnOnConsecutiveCalls([], [$node]);
+    $content_manager->expects($this->once())->method('updateNodeFromRemote')->with($node)->willReturn(TRUE);
+    $content_manager->expects($this->once())->method('saveContentNode')->with($node, FALSE);
+
+    $manager_factory = $this->createMock(ManagerFactory::class);
+    $manager_factory->method('getContentManagerForRemoteType')->with('article')->willReturn($content_manager);
+    $manager_factory->method('getContentManager')->with($node)->willReturn($content_manager);
+
+    $migration = $this->createMock(MigrationInterface::class);
+    $migration->method('getStatus')->willReturn(MigrationInterface::STATUS_IDLE);
+
+    $migration_plugin_manager = $this->createMock(MigrationPluginManagerInterface::class);
+    $migration_plugin_manager->method('getDefinitions')->willReturn([
+      'articles_hpc_content_module' => [
+        'source' => [
+          'remote_source' => 'hpc_content_module',
+          'content_type' => 'article',
+        ],
+      ],
+    ]);
+    $migration_plugin_manager->expects($this->once())
+      ->method('createInstance')
+      ->with('articles_hpc_content_module')
+      ->willReturn($migration);
+
+    $targeted_migration_importer = $this->createMock(TargetedMigrationImporter::class);
+    $targeted_migration_importer->expects($this->once())
+      ->method('import')
+      ->with($migration, 123)
+      ->willReturn(TRUE);
+
+    $lock = $this->createMock(LockBackendInterface::class);
+    $lock->method('acquire')->willReturn(TRUE);
+    $lock->expects($this->once())->method('release')->with('ghi_content_remote_refresh:hpc_content_module:article:123');
+
+    $info_messages = [];
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->method('info')->willReturnCallback(function (string $message, array $context) use (&$info_messages): void {
+      $info_messages[] = [$message, $context];
+    });
+    $logger->expects($this->never())->method('notice');
+    $logger->expects($this->never())->method('error');
+    $logger->expects($this->never())->method('warning');
+
+    $worker = new RemoteRefreshQueue([], 'ghi_content_remote_refresh', []);
+    $this->setProtectedProperty($worker, 'managerFactory', $manager_factory);
+    $this->setProtectedProperty($worker, 'migrationPluginManager', $migration_plugin_manager);
+    $this->setProtectedProperty($worker, 'targetedMigrationImporter', $targeted_migration_importer);
+    $this->setProtectedProperty($worker, 'lock', $lock);
+    $this->setProtectedProperty($worker, 'logger', $logger);
+
+    $worker->processItem((object) [
+      'source' => 'hpc_content_module',
+      'type' => 'article',
+      'id' => 123,
+      'status' => 1,
+      'event' => 'saved',
+    ]);
+
+    $this->assertCount(2, $info_messages);
+    $this->assertSame('Created local @type node @nid from @event event from remote source @source with remote id @remote_id.', $info_messages[0][0]);
+    $this->assertSame('Processed @event event for local @type node @nid from remote source @source with remote id @remote_id.', $info_messages[1][0]);
+    $this->assertSame(789, $info_messages[1][1]['@nid']);
+  }
+
+  /**
+   * Tests that a busy migration delays the item for a later retry.
+   */
+  public function testMissingPublishedItemIsDelayedWhenMigrationIsBusy(): void {
+    $content_manager = $this->createMock(BaseContentManager::class);
+    $content_manager->expects($this->once())
+      ->method('loadNodesForRemoteIds')
+      ->with('hpc_content_module', [123])
+      ->willReturn([]);
+
+    $manager_factory = $this->createMock(ManagerFactory::class);
+    $manager_factory->method('getContentManagerForRemoteType')->with('article')->willReturn($content_manager);
+    $manager_factory->expects($this->never())->method('getContentManager');
+
+    $migration = $this->createMock(MigrationInterface::class);
+    $migration->method('getStatus')->willReturn(MigrationInterface::STATUS_IMPORTING);
+
+    $migration_plugin_manager = $this->createMock(MigrationPluginManagerInterface::class);
+    $migration_plugin_manager->method('getDefinitions')->willReturn([
+      'articles_hpc_content_module' => [
+        'source' => [
+          'remote_source' => 'hpc_content_module',
+          'content_type' => 'article',
+        ],
+      ],
+    ]);
+    $migration_plugin_manager->expects($this->once())
+      ->method('createInstance')
+      ->with('articles_hpc_content_module')
+      ->willReturn($migration);
+
+    $lock = $this->createMock(LockBackendInterface::class);
+    $lock->method('acquire')->willReturn(TRUE);
+    $lock->expects($this->once())->method('release')->with('ghi_content_remote_refresh:hpc_content_module:article:123');
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('notice')
+      ->with(
+        'Delayed remote refresh creating local @type @id from @source because the migration is not idle.',
+        [
+          '@type' => 'article',
+          '@id' => 123,
+          '@source' => 'hpc_content_module',
+        ]
+      );
+    $logger->expects($this->never())->method('info');
+    $logger->expects($this->never())->method('error');
+
+    $worker = new RemoteRefreshQueue([], 'ghi_content_remote_refresh', []);
+    $this->setProtectedProperty($worker, 'managerFactory', $manager_factory);
+    $this->setProtectedProperty($worker, 'migrationPluginManager', $migration_plugin_manager);
+    $this->setProtectedProperty($worker, 'lock', $lock);
+    $this->setProtectedProperty($worker, 'logger', $logger);
+
+    $this->expectException(DelayedRequeueException::class);
+
+    $worker->processItem((object) [
+      'source' => 'hpc_content_module',
+      'type' => 'article',
+      'id' => 123,
+      'status' => 1,
+      'event' => 'saved',
+    ]);
+  }
+
+  /**
+   * Tests that a stale busy-migration item is not retried forever.
+   */
+  public function testMissingPublishedItemStopsRetryingWhenMigrationStaysBusy(): void {
+    $content_manager = $this->createMock(BaseContentManager::class);
+    $content_manager->expects($this->once())
+      ->method('loadNodesForRemoteIds')
+      ->with('hpc_content_module', [123])
+      ->willReturn([]);
+
+    $manager_factory = $this->createMock(ManagerFactory::class);
+    $manager_factory->method('getContentManagerForRemoteType')->with('article')->willReturn($content_manager);
+    $manager_factory->expects($this->never())->method('getContentManager');
+
+    $migration = $this->createMock(MigrationInterface::class);
+    $migration->method('getStatus')->willReturn(MigrationInterface::STATUS_IMPORTING);
+
+    $migration_plugin_manager = $this->createMock(MigrationPluginManagerInterface::class);
+    $migration_plugin_manager->method('getDefinitions')->willReturn([
+      'articles_hpc_content_module' => [
+        'source' => [
+          'remote_source' => 'hpc_content_module',
+          'content_type' => 'article',
+        ],
+      ],
+    ]);
+    $migration_plugin_manager->expects($this->once())
+      ->method('createInstance')
+      ->with('articles_hpc_content_module')
+      ->willReturn($migration);
+
+    $time = $this->createMock(TimeInterface::class);
+    $time->method('getRequestTime')->willReturn(21602);
+
+    $lock = $this->createMock(LockBackendInterface::class);
+    $lock->method('acquire')->willReturn(TRUE);
+    $lock->expects($this->once())->method('release')->with('ghi_content_remote_refresh:hpc_content_module:article:123');
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('error')
+      ->with(
+        'Remote refresh stopped retrying local @type @id from @source because the migration stayed busy for too long.',
+        [
+          '@type' => 'article',
+          '@id' => 123,
+          '@source' => 'hpc_content_module',
+        ]
+      );
+    $logger->expects($this->never())->method('info');
+    $logger->expects($this->never())->method('notice');
+
+    $worker = new RemoteRefreshQueue([], 'ghi_content_remote_refresh', []);
+    $this->setProtectedProperty($worker, 'managerFactory', $manager_factory);
+    $this->setProtectedProperty($worker, 'migrationPluginManager', $migration_plugin_manager);
+    $this->setProtectedProperty($worker, 'time', $time);
+    $this->setProtectedProperty($worker, 'lock', $lock);
+    $this->setProtectedProperty($worker, 'logger', $logger);
+
+    $worker->processItem((object) [
+      'source' => 'hpc_content_module',
+      'type' => 'article',
+      'id' => 123,
+      'status' => 1,
+      'event' => 'saved',
+      'received' => 1,
     ]);
   }
 

--- a/html/modules/custom/ghi_content/tests/src/Unit/Plugin/QueueWorker/RemoteRefreshQueueTest.php
+++ b/html/modules/custom/ghi_content/tests/src/Unit/Plugin/QueueWorker/RemoteRefreshQueueTest.php
@@ -69,7 +69,6 @@ class RemoteRefreshQueueTest extends UnitTestCase {
       'source' => 'hpc_content_module',
       'type' => 'article',
       'id' => 123,
-      'status' => 0,
       'event' => 'deleted',
     ]);
   }
@@ -115,8 +114,7 @@ class RemoteRefreshQueueTest extends UnitTestCase {
       'source' => 'hpc_content_module',
       'type' => 'article',
       'id' => 123,
-      'status' => 0,
-      'event' => 'saved',
+      'event' => 'trashed',
     ]);
   }
 
@@ -189,7 +187,6 @@ class RemoteRefreshQueueTest extends UnitTestCase {
       'source' => 'hpc_content_module',
       'type' => 'article',
       'id' => 123,
-      'status' => 1,
       'event' => 'saved',
     ]);
 
@@ -260,7 +257,6 @@ class RemoteRefreshQueueTest extends UnitTestCase {
       'source' => 'hpc_content_module',
       'type' => 'article',
       'id' => 123,
-      'status' => 1,
       'event' => 'saved',
     ]);
   }
@@ -328,7 +324,6 @@ class RemoteRefreshQueueTest extends UnitTestCase {
       'source' => 'hpc_content_module',
       'type' => 'article',
       'id' => 123,
-      'status' => 1,
       'event' => 'saved',
       'received' => 1,
     ]);

--- a/html/modules/custom/ghi_content/tests/src/Unit/Plugin/QueueWorker/RemoteRefreshQueueTest.php
+++ b/html/modules/custom/ghi_content/tests/src/Unit/Plugin/QueueWorker/RemoteRefreshQueueTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\Tests\ghi_content\Unit\Plugin\QueueWorker;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Lock\LockBackendInterface;
+use Drupal\ghi_content\ContentManager\BaseContentManager;
+use Drupal\ghi_content\ContentManager\ManagerFactory;
+use Drupal\ghi_content\Entity\ContentBase;
+use Drupal\ghi_content\Plugin\QueueWorker\RemoteRefreshQueue;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests remote refresh queue items.
+ *
+ * @group ghi_content
+ */
+class RemoteRefreshQueueTest extends UnitTestCase {
+
+  /**
+   * Tests that delete events are logged when refresh items are processed.
+   */
+  public function testDeleteEventIsLogged(): void {
+    $node = $this->createMock(ContentBase::class);
+    $node->expects($this->once())->method('setUnpublished');
+    $node->method('id')->willReturn(789);
+
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->method('loadByProperties')->willReturn([$node]);
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('node')->willReturn($storage);
+
+    $content_manager = $this->createMock(BaseContentManager::class);
+    $content_manager->expects($this->never())->method('updateNodeFromRemote');
+    $content_manager->expects($this->once())->method('saveContentNode')->with($node, FALSE);
+
+    $manager_factory = $this->createMock(ManagerFactory::class);
+    $manager_factory->method('getContentManager')->with($node)->willReturn($content_manager);
+
+    $lock = $this->createMock(LockBackendInterface::class);
+    $lock->method('acquire')->willReturn(TRUE);
+    $lock->expects($this->once())->method('release')->with('ghi_content_remote_refresh:hpc_content_module:article:123');
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('info')
+      ->with(
+        'Processed @event event for local @type node @nid from remote source @source with remote id @remote_id.',
+        $this->callback(function (array $context) {
+          return $context['@event'] === 'deleted'
+            && $context['@type'] === 'article'
+            && $context['@nid'] === 789
+            && $context['@source'] === 'hpc_content_module'
+            && $context['@remote_id'] === 123;
+        })
+      );
+
+    $worker = new RemoteRefreshQueue([], 'ghi_content_remote_refresh', []);
+    $this->setProtectedProperty($worker, 'entityTypeManager', $entity_type_manager);
+    $this->setProtectedProperty($worker, 'managerFactory', $manager_factory);
+    $this->setProtectedProperty($worker, 'lock', $lock);
+    $this->setProtectedProperty($worker, 'logger', $logger);
+
+    $worker->processItem((object) [
+      'source' => 'hpc_content_module',
+      'type' => 'article',
+      'id' => 123,
+      'status' => 0,
+      'event' => 'deleted',
+    ]);
+  }
+
+  /**
+   * Set a protected property on an object.
+   *
+   * @param object $object
+   *   The object.
+   * @param string $property
+   *   The property name.
+   * @param mixed $value
+   *   The property value.
+   */
+  private function setProtectedProperty(object $object, string $property, $value): void {
+    $reflection = new \ReflectionProperty($object, $property);
+    $reflection->setAccessible(TRUE);
+    $reflection->setValue($object, $value);
+  }
+
+}

--- a/html/modules/custom/ghi_content/tests/src/Unit/RemoteSource/HpcContentModuleTest.php
+++ b/html/modules/custom/ghi_content/tests/src/Unit/RemoteSource/HpcContentModuleTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Drupal\Tests\ghi_content\Unit\RemoteSource;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\ghi_content\ContentManager\ArticleManager;
+use Drupal\ghi_content\Plugin\RemoteSource\HpcContentModule;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Tests the HPC content module remote source.
+ *
+ * @group ghi_content
+ */
+class HpcContentModuleTest extends UnitTestCase {
+
+  /**
+   * Tests that remote refresh settings use runtime config overrides.
+   */
+  public function testRemoteRefreshSettingsUseRuntimeOverrides(): void {
+    $remote_source = $this->createRemoteSource([
+      'webhook_secret' => 'runtime-secret',
+      'signature_ttl' => 120,
+      'max_body_size' => 2048,
+    ]);
+
+    $this->assertSame('runtime-secret', $remote_source->getRemoteRefreshWebhookSecret());
+    $this->assertSame(120, $remote_source->getRemoteRefreshSignatureTtl());
+    $this->assertSame(2048, $remote_source->getRemoteRefreshMaxBodySize());
+  }
+
+  /**
+   * Tests that an empty configured secret keeps the stored secret.
+   */
+  public function testSetConfigurationPreservesStoredSecretWhenSubmittedSecretIsEmpty(): void {
+    $remote_source = $this->createRemoteSource([
+      'webhook_secret' => 'runtime-secret',
+      'signature_ttl' => 120,
+      'max_body_size' => 2048,
+    ]);
+
+    $remote_source->setConfiguration([
+      'remote_refresh' => [
+        'webhook_secret' => '',
+        'signature_ttl' => 300,
+        'max_body_size' => 4096,
+      ],
+    ]);
+
+    $configuration = $remote_source->getConfiguration();
+    $this->assertSame('stored-secret', $configuration['remote_refresh']['webhook_secret']);
+  }
+
+  /**
+   * Creates a remote source with mocked config.
+   *
+   * @param array $runtime_refresh_settings
+   *   Runtime remote refresh settings.
+   * @param string[] $overridden_refresh_settings
+   *   Overridden remote refresh settings.
+   *
+   * @return \Drupal\ghi_content\Plugin\RemoteSource\HpcContentModule
+   *   The remote source plugin.
+   */
+  private function createRemoteSource(array $runtime_refresh_settings = [], array $overridden_refresh_settings = []): HpcContentModule {
+    $stored_configuration = [
+      'base_url' => 'https://content.example.org',
+      'endpoint' => 'ncms',
+      'access_key' => NULL,
+      'remote_refresh' => [
+        'webhook_secret' => 'stored-secret',
+        'signature_ttl' => 300,
+        'max_body_size' => 4096,
+      ],
+    ];
+
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('getOriginal')
+      ->with('hpc_content_module')
+      ->willReturn($stored_configuration);
+    $config->method('hasOverrides')
+      ->willReturnCallback(function (string $key) use ($overridden_refresh_settings) {
+        $prefix = 'hpc_content_module.remote_refresh.';
+        if (strpos($key, $prefix) === 0) {
+          return in_array(substr($key, strlen($prefix)), $overridden_refresh_settings, TRUE);
+        }
+        return FALSE;
+      });
+    $config->method('get')
+      ->willReturnCallback(function (string $key) use ($runtime_refresh_settings) {
+        $prefix = 'hpc_content_module.remote_refresh.';
+        if (strpos($key, $prefix) === 0) {
+          return $runtime_refresh_settings[substr($key, strlen($prefix))] ?? NULL;
+        }
+        return NULL;
+      });
+
+    $config_factory = $this->createMock(ConfigFactoryInterface::class);
+    $config_factory->method('get')
+      ->with('ghi_content.remote_sources')
+      ->willReturn($config);
+
+    return new HpcContentModule(
+      [],
+      'hpc_content_module',
+      [
+        'id' => 'hpc_content_module',
+        'label' => 'HPC Content Module',
+      ],
+      $this->createMock(ClientInterface::class),
+      new RequestStack(),
+      $config_factory,
+      $this->createMock(ArticleManager::class),
+    );
+  }
+
+}

--- a/html/modules/custom/ghi_user/src/Form/UserFormAlter.php
+++ b/html/modules/custom/ghi_user/src/Form/UserFormAlter.php
@@ -172,19 +172,27 @@ class UserFormAlter {
    *   The form state object.
    */
   public function alterEditForm(&$form, FormStateInterface $form_state) {
+    /** @var \Drupal\user\UserInterface $user */
+    $user = $form_state->getFormObject()->getEntity();
+
     // Disable password fields.
-    $form['account']['pass']['#access'] = FALSE;
-    $form['account']['current_pass']['#access'] = FALSE;
+    if (isset($form['account']['pass'])) {
+      $form['account']['pass']['#access'] = FALSE;
+      if ($user->isNew()) {
+        $form['account']['pass']['#required'] = FALSE;
+        array_unshift($form['#validate'], [self::class, 'setGeneratedPassword']);
+      }
+    }
+    if (isset($form['account']['current_pass'])) {
+      $form['account']['current_pass']['#access'] = FALSE;
+    }
     // Don't require password for changing the mail address.
     $form_state->set('user_pass_reset', 1);
 
     if ($this->currentUser->hasPermission('administer users')) {
-      // Administrator should see all fields.
+      // Administrator should see all other fields.
       return;
     }
-
-    /** @var \Drupal\user\UserInterface $user */
-    $user = $form_state->getFormObject()->getEntity();
 
     // For non-administrators we provide a customized display of the form where
     // most of the fields are disabled but still shown for information purposes.
@@ -237,6 +245,15 @@ class UserFormAlter {
       if (!in_array($key, $keep_children)) {
         $form[$key]['#access'] = FALSE;
       }
+    }
+  }
+
+  /**
+   * Adds a generated password for new accounts created through the UI.
+   */
+  public static function setGeneratedPassword(array &$form, FormStateInterface $form_state) {
+    if ($form_state->isValueEmpty('pass')) {
+      $form_state->setValue('pass', \Drupal::service('password_generator')->generate());
     }
   }
 

--- a/html/sites/default/settings.docksal.php
+++ b/html/sites/default/settings.docksal.php
@@ -34,6 +34,11 @@ $config['ghi_content.remote_sources'] = [
     'base_url' => 'https://content.hpc.tools',
     'endpoint' => 'ncms',
     'access_key' => getenv('CM_KEY'),
+    'remote_refresh' => [
+      'webhook_secret' => getenv('CM_WEBHOOK_SECRET') ?: '',
+      'signature_ttl' => 300,
+      'max_body_size' => 4096,
+    ],
   ],
 ];
 


### PR DESCRIPTION
- **HPC-10373: Add signed webhook queue for remote content refreshes**
- **HPC-10373: UNrelated change -  make local docksal command more robust**
- **HPC-10373: Harden remote refresh webhook validation**
- **HPC-10373: Support override-aware remote refresh webhook settings**
- **HPC-10373: Support creating missing HA content from remote refresh events**
- **HPC-10373: Document and tighten remote refresh webhook contract**
- **HPC-10569: Generate hidden password for admin-created users**
