### PR TITLE
fix(security): Use named captures in the mapbox cache twiddles.

### DIFF
--- a/docker/etc/nginx/custom/03_mapbox.conf
+++ b/docker/etc/nginx/custom/03_mapbox.conf
@@ -45,8 +45,8 @@ location /mapbox/ {
 
   ## Remove the sku parameter as it's always different.
   set $cache_uri $mapbox_request_uri;
-  if ($cache_uri ~ "^(.*)[?&]sku=[^&]+(.*)$") {
-    set $cache_uri $1$2;
+  if ($cache_uri ~ "^(?<mapbox_cache_path>.*)[?&]sku=[^&]+(?<mapbox_cache_sku>.*)$") {
+    set $cache_uri $mapbox_cache_path$mapbox_cache_sku;
   }
 
   ## Cache the resources for 14 days.


### PR DESCRIPTION
The CVE says this exact config is not vulnerable, but let's update our regexes everywhere and be both safe and consistent.

Refs: OPS-12132